### PR TITLE
Add Solr Infrastructure

### DIFF
--- a/infrastructure/cinco/config/admin/app-servers.yaml
+++ b/infrastructure/cinco/config/admin/app-servers.yaml
@@ -16,3 +16,4 @@ parameters:
     App</h1> <h2>Congratulations!</h2> <p>Your application is now
     running on a container in Amazon ECS.</p> </div></body></html>' >
     /usr/local/apache2/htdocs/index.html && httpd-foreground"
+  DBInstanceSecurityGroup: !stack_output admin/db.yaml::RDSSecurityGroup

--- a/infrastructure/cinco/config/admin/db.yaml
+++ b/infrastructure/cinco/config/admin/db.yaml
@@ -7,4 +7,4 @@ parameters:
   SubnetIDs: !environment_variable SUBNET_IDS
   DBUsername: !environment_variable DB_USERNAME
   DBPassword: !environment_variable DB_PASSWORD
-  ApplicationSecurityGroup: !stack_output admin/app-servers.yaml::SecurityGroup
+  ApplicationSecurityGroup: !stack_output admin/app-servers.yaml::ServiceSecurityGroup

--- a/infrastructure/cinco/config/admin/db.yaml
+++ b/infrastructure/cinco/config/admin/db.yaml
@@ -7,4 +7,3 @@ parameters:
   SubnetIDs: !environment_variable SUBNET_IDS
   DBUsername: !environment_variable DB_USERNAME
   DBPassword: !environment_variable DB_PASSWORD
-  ApplicationSecurityGroup: !stack_output admin/app-servers.yaml::ServiceSecurityGroup

--- a/infrastructure/cinco/config/arclight/solr-efs.yaml
+++ b/infrastructure/cinco/config/arclight/solr-efs.yaml
@@ -1,0 +1,10 @@
+template:
+  path: efs.yaml
+  type: file
+parameters:
+  Namespace: cinco-solr
+  VpcId: !environment_variable VPC_ID
+  PrivateSubnetId1: !environment_variable PRIVATE_SUBNET_1
+  PrivateSubnetId2: !environment_variable PRIVATE_SUBNET_2
+  EFSAccessPointUserGroup: "8983"
+  EFSAccessPointPath: "/var/solr"

--- a/infrastructure/cinco/config/arclight/solr-writer.yaml
+++ b/infrastructure/cinco/config/arclight/solr-writer.yaml
@@ -27,9 +27,6 @@ sceptre_user_data:
       ContainerPath: "/var/solr"
   TaskRole: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn
   HttpAccessList:
-    - Name: "Admin"
-      Id: !stack_output admin/app-servers.yaml::ServiceSecurityGroup
-    # - Name: "Arclight"
-    #   Id: !stack_output arclight/arclight.yaml::ServiceSecurityGroup
-    # - Name: "PADAirflow"
-    #   Id: !environment_variable PAD_AIRFLOW_SECURITY_GROUP
+    - !stack_output admin/app-servers.yaml::ServiceSecurityGroup
+    # - !stack_output arclight/arclight.yaml::ServiceSecurityGroup
+    # - !environment_variable PAD_AIRFLOW_SECURITY_GROUP

--- a/infrastructure/cinco/config/arclight/solr-writer.yaml
+++ b/infrastructure/cinco/config/arclight/solr-writer.yaml
@@ -25,7 +25,7 @@ sceptre_user_data:
   ContainerMountPoints:
     - SourceVolume: "cinco-solr-efs-volume"
       ContainerPath: "/var/solr"
-  TaskRole: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn
+  TaskRole: !stack_output arclight/solr-efs.yaml::EfsWriterRoleArn
   HttpAccessList:
     - !stack_output admin/app-servers.yaml::ServiceSecurityGroup
     # - !stack_output arclight/arclight.yaml::ServiceSecurityGroup

--- a/infrastructure/cinco/config/arclight/solr-writer.yaml
+++ b/infrastructure/cinco/config/arclight/solr-writer.yaml
@@ -1,0 +1,22 @@
+template:
+  path: ecs-webapp.j2
+  type: file
+parameters:
+  ClusterName: !stack_output arclight/solr.yaml::ECSCluster
+  Namespace: cinco-solr-writer
+  VpcId: !environment_variable VPC_ID
+  SubnetIDs: !environment_variable SUBNET_IDS
+  ContainerImage: 'public.ecr.aws/docker/library/solr:9.6.1'
+  ContainerPort: 8983
+  ContainerCount: 1
+  ContainerEntryPoint: "docker-entrypoint.sh"
+  ContainerCommand: "solr-foreground"
+  HealthCheckPath: "/solr/#/"
+
+sceptre_user_data:
+  EFSVolumes:
+    Name: "cinco-solr-efs-volume"
+    Path: "/var/solr"
+    FilesystemId: !stack_output arclight/solr-efs.yaml::EfsFileSystemId
+    AccessPointId: !stack_output arclight/solr-efs.yaml::EfsAccessPointId
+    TaskRoleArn: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn

--- a/infrastructure/cinco/config/arclight/solr-writer.yaml
+++ b/infrastructure/cinco/config/arclight/solr-writer.yaml
@@ -14,12 +14,18 @@ parameters:
   HealthCheckPath: "/solr/#/"
 
 sceptre_user_data:
-  EFSVolumes:
-    Name: "cinco-solr-efs-volume"
-    Path: "/var/solr"
-    FilesystemId: !stack_output arclight/solr-efs.yaml::EfsFileSystemId
-    AccessPointId: !stack_output arclight/solr-efs.yaml::EfsAccessPointId
-    TaskRoleArn: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn
+  Volumes:
+    - Name: "cinco-solr-efs-volume"
+      EFSVolumeConfiguration:
+        FilesystemId: !stack_output arclight/solr-efs.yaml::EfsFileSystemId
+        AuthorizationConfig:
+          AccessPointId: !stack_output arclight/solr-efs.yaml::EfsAccessPointId
+          IAM: ENABLED
+        TransitEncryption: ENABLED
+  ContainerMountPoints:
+    - SourceVolume: "cinco-solr-efs-volume"
+      ContainerPath: "/var/solr"
+  TaskRole: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn
   HttpAccessList:
     - Name: "Admin"
       Id: !stack_output admin/app-servers.yaml::ServiceSecurityGroup

--- a/infrastructure/cinco/config/arclight/solr-writer.yaml
+++ b/infrastructure/cinco/config/arclight/solr-writer.yaml
@@ -20,3 +20,10 @@ sceptre_user_data:
     FilesystemId: !stack_output arclight/solr-efs.yaml::EfsFileSystemId
     AccessPointId: !stack_output arclight/solr-efs.yaml::EfsAccessPointId
     TaskRoleArn: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn
+  HttpAccessList:
+    - Name: "Admin"
+      Id: !stack_output admin/app-servers.yaml::ServiceSecurityGroup
+    # - Name: "Arclight"
+    #   Id: !stack_output arclight/arclight.yaml::ServiceSecurityGroup
+    # - Name: "PADAirflow"
+    #   Id: !environment_variable PAD_AIRFLOW_SECURITY_GROUP

--- a/infrastructure/cinco/config/arclight/solr.yaml
+++ b/infrastructure/cinco/config/arclight/solr.yaml
@@ -26,9 +26,6 @@ sceptre_user_data:
       ContainerPath: "/var/solr"
   TaskRole: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn
   HttpAccessList:
-    - Name: "Admin"
-      Id: !stack_output admin/app-servers.yaml::ServiceSecurityGroup
-    # - Name: "Arclight"
-    #   Id: !stack_output arclight/arclight.yaml::ServiceSecurityGroup
-    # - Name: "PADAirflow"
-    #   Id: !environment_variable PAD_AIRFLOW_SECURITY_GROUP
+    - !stack_output admin/app-servers.yaml::ServiceSecurityGroup
+    # - !stack_output arclight/arclight.yaml::ServiceSecurityGroup
+    # - !environment_variable PAD_AIRFLOW_SECURITY_GROUP

--- a/infrastructure/cinco/config/arclight/solr.yaml
+++ b/infrastructure/cinco/config/arclight/solr.yaml
@@ -11,3 +11,11 @@ parameters:
   ContainerEntryPoint: "docker-entrypoint.sh"
   ContainerCommand: "solr-foreground"
   HealthCheckPath: "/solr/#/"
+
+sceptre_user_data:
+  EFSVolumes:
+    Name: "cinco-solr-efs-volume"
+    Path: "/var/solr"
+    FilesystemId: !stack_output arclight/solr-efs.yaml::EfsFileSystemId
+    AccessPointId: !stack_output arclight/solr-efs.yaml::EfsAccessPointId
+    TaskRoleArn: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn

--- a/infrastructure/cinco/config/arclight/solr.yaml
+++ b/infrastructure/cinco/config/arclight/solr.yaml
@@ -1,0 +1,13 @@
+template:
+  path: ecs-webapp.j2
+  type: file
+parameters:
+  Namespace: cinco-solr
+  VpcId: !environment_variable VPC_ID
+  SubnetIDs: !environment_variable SUBNET_IDS
+  ContainerImage: 'public.ecr.aws/docker/library/solr:9.6.1'
+  ContainerPort: 8983
+  ContainerCount: 1
+  ContainerEntryPoint: "docker-entrypoint.sh"
+  ContainerCommand: "solr-foreground"
+  HealthCheckPath: "/solr/#/"

--- a/infrastructure/cinco/config/arclight/solr.yaml
+++ b/infrastructure/cinco/config/arclight/solr.yaml
@@ -13,12 +13,18 @@ parameters:
   HealthCheckPath: "/solr/#/"
 
 sceptre_user_data:
-  EFSVolumes:
-    Name: "cinco-solr-efs-volume"
-    Path: "/var/solr"
-    FilesystemId: !stack_output arclight/solr-efs.yaml::EfsFileSystemId
-    AccessPointId: !stack_output arclight/solr-efs.yaml::EfsAccessPointId
-    TaskRoleArn: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn
+  Volumes:
+    - Name: "cinco-solr-efs-volume"
+      EFSVolumeConfiguration:
+        FilesystemId: !stack_output arclight/solr-efs.yaml::EfsFileSystemId
+        AuthorizationConfig:
+          AccessPointId: !stack_output arclight/solr-efs.yaml::EfsAccessPointId
+          IAM: ENABLED
+        TransitEncryption: ENABLED
+  ContainerMountPoints:
+    - SourceVolume: "cinco-solr-efs-volume"
+      ContainerPath: "/var/solr"
+  TaskRole: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn
   HttpAccessList:
     - Name: "Admin"
       Id: !stack_output admin/app-servers.yaml::ServiceSecurityGroup

--- a/infrastructure/cinco/config/arclight/solr.yaml
+++ b/infrastructure/cinco/config/arclight/solr.yaml
@@ -24,7 +24,7 @@ sceptre_user_data:
   ContainerMountPoints:
     - SourceVolume: "cinco-solr-efs-volume"
       ContainerPath: "/var/solr"
-  TaskRole: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn
+  TaskRole: !stack_output arclight/solr-efs.yaml::EfsReaderRoleArn
   HttpAccessList:
     - !stack_output admin/app-servers.yaml::ServiceSecurityGroup
     # - !stack_output arclight/arclight.yaml::ServiceSecurityGroup

--- a/infrastructure/cinco/config/arclight/solr.yaml
+++ b/infrastructure/cinco/config/arclight/solr.yaml
@@ -19,3 +19,10 @@ sceptre_user_data:
     FilesystemId: !stack_output arclight/solr-efs.yaml::EfsFileSystemId
     AccessPointId: !stack_output arclight/solr-efs.yaml::EfsAccessPointId
     TaskRoleArn: !stack_output arclight/solr-efs.yaml::EfsTaskRoleArn
+  HttpAccessList:
+    - Name: "Admin"
+      Id: !stack_output admin/app-servers.yaml::ServiceSecurityGroup
+    # - Name: "Arclight"
+    #   Id: !stack_output arclight/arclight.yaml::ServiceSecurityGroup
+    # - Name: "PADAirflow"
+    #   Id: !environment_variable PAD_AIRFLOW_SECURITY_GROUP

--- a/infrastructure/cinco/templates/ecs-webapp.j2
+++ b/infrastructure/cinco/templates/ecs-webapp.j2
@@ -54,7 +54,6 @@ Parameters:
 
 Conditions:
   HasSSLCert: !Not [!Equals [!Ref SSLCertArn, ""]]
-  HasContainerPort: !Not [!Equals [!Ref ContainerPort, 80]]
   CreateCluster: !Equals [!Ref ClusterName, ""]
 
 Resources:
@@ -157,7 +156,7 @@ Resources:
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Security Group for application load balancer and, if container listens on port 80, ECS service
+      GroupDescription: Security Group for application load balancer
       GroupName: !Sub ${Namespace}-securitygroup
       VpcId: !Ref 'VpcId'
       SecurityGroupIngress:
@@ -180,9 +179,8 @@ Resources:
 
   ServiceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
-    Condition: HasContainerPort
     Properties:
-      GroupDescription: Security Group for ECS service, if container listens on a port other than 80
+      GroupDescription: Security Group for ECS service
       GroupName: !Sub ${Namespace}-service-securitygroup
       VpcId: !Ref 'VpcId'
       SecurityGroupIngress:
@@ -209,8 +207,8 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups:
-            - !If [HasContainerPort, !Ref ServiceSecurityGroup, !Ref SecurityGroup]
+          SecurityGroups: 
+            - !Ref ServiceSecurityGroup
           Subnets: !Ref SubnetIDs
       PlatformVersion: 'LATEST'
       DeploymentConfiguration:
@@ -280,6 +278,10 @@ Outputs:
   SecurityGroup:
     Description: The Security Group
     Value: !Ref SecurityGroup
+
+  ServiceSecurityGroup:
+    Description: The Service Security Group
+    Value: !Ref ServiceSecurityGroup
 
   ECSService:
     Description: The ECS Service

--- a/infrastructure/cinco/templates/ecs-webapp.j2
+++ b/infrastructure/cinco/templates/ecs-webapp.j2
@@ -51,10 +51,15 @@ Parameters:
     Description: The ARN of the SSL certificate to use for the load balancer
     Type: String
     Default: ""
+  DBInstanceSecurityGroup:
+    Type: String
+    Description: The security group for the RDS instance
+    Default: ""
 
 Conditions:
   HasSSLCert: !Not [!Equals [!Ref SSLCertArn, ""]]
   CreateCluster: !Equals [!Ref ClusterName, ""]
+  HasDBInstance: !Not [!Equals [!Ref DBInstanceSecurityGroup, ""]]
 
 Resources:
   ECSCluster:
@@ -190,6 +195,16 @@ Resources:
           ToPort: !Ref ContainerPort
           SourceSecurityGroupId: !GetAtt SecurityGroup.GroupId
 
+  DBInstanceSecurityGroupApplicationIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Condition: HasDBInstance
+    Properties:
+      GroupId: !Ref DBInstanceSecurityGroup
+      IpProtocol: "tcp"
+      FromPort: "5432"
+      ToPort: "5432"
+      SourceSecurityGroupId: !Ref ServiceSecurityGroup
+
   ECSService:
     Type: AWS::ECS::Service
     Properties:
@@ -207,7 +222,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups: 
+          SecurityGroups:
             - !Ref ServiceSecurityGroup
           Subnets: !Ref SubnetIDs
       PlatformVersion: 'LATEST'

--- a/infrastructure/cinco/templates/ecs-webapp.j2
+++ b/infrastructure/cinco/templates/ecs-webapp.j2
@@ -59,6 +59,9 @@ Resources:
       ClusterName: !Ref Namespace
       CapacityProviders:
         - FARGATE
+      ClusterSettings:
+        - Name: containerInsights
+          Value: disabled
 
   ECSTaskExecutionRole:
     Type: AWS::IAM::Role
@@ -104,7 +107,7 @@ Resources:
           Essential: true
           EntryPoint: !Ref ContainerEntryPoint
           Command: !Ref ContainerCommand
-          {% if sceptre_user_data and sceptre_user_data.ContainerEnvironment %}
+          {% if sceptre_user_data and sceptre_user_data.ContainerEnvironment is defined %}
           Environment:
             {% for item in sceptre_user_data.ContainerEnvironment %}
             - Name: "{{ item.Name }}"

--- a/infrastructure/cinco/templates/ecs-webapp.j2
+++ b/infrastructure/cinco/templates/ecs-webapp.j2
@@ -6,6 +6,10 @@ Parameters:
   Namespace:
     Description: The namespace for the ECS Application
     Type: String
+  ClusterName:
+    Description: The name of the ECS cluster - if not provided, will create one using namespace.
+    Type: String
+    Default: ""
   VpcId:
     Description: The VPC the ECS service will run in
     Type: AWS::EC2::VPC::Id
@@ -51,10 +55,12 @@ Parameters:
 Conditions:
   HasSSLCert: !Not [!Equals [!Ref SSLCertArn, ""]]
   HasContainerPort: !Not [!Equals [!Ref ContainerPort, 80]]
+  CreateCluster: !Equals [!Ref ClusterName, ""]
 
 Resources:
   ECSCluster:
     Type: AWS::ECS::Cluster
+    Condition: CreateCluster
     Properties:
       ClusterName: !Ref Namespace
       CapacityProviders:
@@ -189,7 +195,7 @@ Resources:
   ECSService:
     Type: AWS::ECS::Service
     Properties:
-      Cluster: !Ref ECSCluster
+      Cluster: !If [CreateCluster, !Ref ECSCluster, !Ref ClusterName]
       TaskDefinition: !Ref TaskDefinition
       LaunchType: FARGATE
       ServiceName: !Sub ${Namespace}-service
@@ -265,7 +271,7 @@ Resources:
 Outputs:
   ECSCluster:
     Description: The ECS Cluster
-    Value: !Ref ECSCluster
+    Value: !If [CreateCluster, !Ref ECSCluster, !Ref ClusterName]
 
   TaskDefinition:
     Description: The ECS Task Definition

--- a/infrastructure/cinco/templates/ecs-webapp.j2
+++ b/infrastructure/cinco/templates/ecs-webapp.j2
@@ -164,13 +164,38 @@ Resources:
       GroupDescription: Security Group for application load balancer
       GroupName: !Sub ${Namespace}-securitygroup
       VpcId: !Ref 'VpcId'
+      {% if sceptre_user_data and sceptre_user_data.HttpAccessList is defined %}
+      SecurityGroupIngress:
+        {% for securitygroup in sceptre_user_data.HttpAccessList %}
+        - Description: Allow HTTP access
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourceSecurityGroupId: {{ securitygroup.Id }}
+        {% endfor %}
+      {% else %}
       SecurityGroupIngress:
         - Description: Allow HTTP access
           IpProtocol: tcp
-          FromPort: '80'
-          ToPort: '80'
-          CidrIp: '0.0.0.0/0'
+          FromPort: 80
+          ToPort: 80
+          CidrIp: "0.0.0.0/0"
+      {% endif %}
 
+  {% if sceptre_user_data and sceptre_user_data.HttpAccessList is defined %}
+  {% for securitygroup in sceptre_user_data.HttpAccessList %}
+  SecurityGroupHttpsIngress{{ securitygroup.Name }}:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HasSSLCert
+    Properties:
+      Description: Allow HTTPS access
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      SourceSecurityGroupId: {{ securitygroup.Id }}
+  {% endfor %}
+  {% else %}
   SecurityGroupHttpsIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Condition: HasSSLCert
@@ -181,6 +206,7 @@ Resources:
       FromPort: 443
       ToPort: 443
       CidrIp: "0.0.0.0/0"
+  {% endif %}
 
   ServiceSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/infrastructure/cinco/templates/ecs-webapp.j2
+++ b/infrastructure/cinco/templates/ecs-webapp.j2
@@ -131,21 +131,14 @@ Resources:
               awslogs-group: !Sub /ecs/${Namespace}-task-definition
               awslogs-region: us-west-2
               awslogs-stream-prefix: ecs
-          {% if sceptre_user_data and sceptre_user_data.EFSVolumes is defined %}
-          MountPoints:
-            - SourceVolume: {{ sceptre_user_data.EFSVolumes.Name }}
-              ContainerPath: {{ sceptre_user_data.EFSVolumes.Path }}
+          {% if sceptre_user_data and sceptre_user_data.ContainerMountPoints is defined %}
+          MountPoints: {{ sceptre_user_data.ContainerMountPoints }}
           {% endif %}
-      {% if sceptre_user_data and sceptre_user_data.EFSVolumes is defined %}
-      Volumes:
-        - Name: {{ sceptre_user_data.EFSVolumes.Name }}
-          EFSVolumeConfiguration:
-            FilesystemId: {{ sceptre_user_data.EFSVolumes.FilesystemId }}
-            AuthorizationConfig:
-              AccessPointId: {{ sceptre_user_data.EFSVolumes.AccessPointId }}
-              IAM: ENABLED
-            TransitEncryption: ENABLED
-      TaskRoleArn: {{ sceptre_user_data.EFSVolumes.TaskRoleArn }}
+      {% if sceptre_user_data and sceptre_user_data.Volumes is defined %}
+      Volumes: {{ sceptre_user_data.Volumes }}
+      {% endif %}
+      {% if sceptre_user_data and sceptre_user_data.TaskRole is defined %}
+      TaskRoleArn: {{ sceptre_user_data.TaskRole }}
       {% endif %}
       Family: !Sub ${Namespace}-task-definition
       ExecutionRoleArn: !GetAtt 'ECSTaskExecutionRole.Arn'

--- a/infrastructure/cinco/templates/ecs-webapp.j2
+++ b/infrastructure/cinco/templates/ecs-webapp.j2
@@ -121,6 +121,22 @@ Resources:
               awslogs-group: !Sub /ecs/${Namespace}-task-definition
               awslogs-region: us-west-2
               awslogs-stream-prefix: ecs
+          {% if sceptre_user_data and sceptre_user_data.EFSVolumes is defined %}
+          MountPoints:
+            - SourceVolume: {{ sceptre_user_data.EFSVolumes.Name }}
+              ContainerPath: {{ sceptre_user_data.EFSVolumes.Path }}
+          {% endif %}
+      {% if sceptre_user_data and sceptre_user_data.EFSVolumes is defined %}
+      Volumes:
+        - Name: {{ sceptre_user_data.EFSVolumes.Name }}
+          EFSVolumeConfiguration:
+            FilesystemId: {{ sceptre_user_data.EFSVolumes.FilesystemId }}
+            AuthorizationConfig:
+              AccessPointId: {{ sceptre_user_data.EFSVolumes.AccessPointId }}
+              IAM: ENABLED
+            TransitEncryption: ENABLED
+      TaskRoleArn: {{ sceptre_user_data.EFSVolumes.TaskRoleArn }}
+      {% endif %}
       Family: !Sub ${Namespace}-task-definition
       ExecutionRoleArn: !GetAtt 'ECSTaskExecutionRole.Arn'
       NetworkMode: awsvpc

--- a/infrastructure/cinco/templates/ecs-webapp.j2
+++ b/infrastructure/cinco/templates/ecs-webapp.j2
@@ -56,6 +56,47 @@ Parameters:
     Description: The security group for the RDS instance
     Default: ""
 
+{# In addition to the CloudFormation Parameters listed above, this template also supports
+   the following sceptre_user_data parameters:
+
+  ContainerEnvironment:
+    Type: a list of key-value pairs
+    Description: environment variables to set in the container, eg:
+      ContainerEnvironment:
+        - ENV_VAR: value
+    Required: false - if not provided, no environment variables will be set
+
+  HttpAccessList:
+    Type: a list of security group ids
+    Description: If provided, whitelists access to the container via the load balancer
+      over HTTP and, if an SSL cert is provided, HTTPS e.g.:
+      HttpAccessList:
+        - sg-12345678
+    Required: false - if not provided, the load balancer's SecurityGroups will allow
+      access to ports 80 and 443 from everywhere.
+
+  Volumes:
+    Type: a list of AWS::ECS::TaskDefinition Volumes
+      https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-volume.html
+    Description: Volume configuration for tasks launched by the task definnition
+      Volume Name value corresponds to SourceVolume value in ContainerMountPoints
+    Required: false - if not provided, no volumes will be configured
+
+  ContainerMountPoints:
+    Type: a list of AWS::ECS::TaskDefinition MountPoints
+      https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-mountpoint.html
+    Description: a list of mount points for the container
+      SourceVolume corresponds to the Name value in Volumes
+    Required: false - if not provided, no mount points will be configured
+
+  TaskRole:
+    Type: an AWS::IAM::Role Arn
+    Description: a role to grant permissions to task containers
+      https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-taskrolearn
+    Required: false - if not provided, no role will be configured.
+      required if an EFS Volume is configured, though.
+  #}
+
 Conditions:
   HasSSLCert: !Not [!Equals [!Ref SSLCertArn, ""]]
   CreateCluster: !Equals [!Ref ClusterName, ""]
@@ -164,7 +205,7 @@ Resources:
           IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          SourceSecurityGroupId: {{ securitygroup.Id }}
+          SourceSecurityGroupId: {{ securitygroup }}
         {% endfor %}
       {% else %}
       SecurityGroupIngress:
@@ -177,7 +218,7 @@ Resources:
 
   {% if sceptre_user_data and sceptre_user_data.HttpAccessList is defined %}
   {% for securitygroup in sceptre_user_data.HttpAccessList %}
-  SecurityGroupHttpsIngress{{ securitygroup.Name }}:
+  SecurityGroupHttpsIngress{{ loop.index }}:
     Type: AWS::EC2::SecurityGroupIngress
     Condition: HasSSLCert
     Properties:
@@ -186,7 +227,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 443
       ToPort: 443
-      SourceSecurityGroupId: {{ securitygroup.Id }}
+      SourceSecurityGroupId: {{ securitygroup }}
   {% endfor %}
   {% else %}
   SecurityGroupHttpsIngress:

--- a/infrastructure/cinco/templates/efs.yaml
+++ b/infrastructure/cinco/templates/efs.yaml
@@ -1,0 +1,140 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: EFS Volume
+
+Parameters:
+  Namespace:
+    Description: The namespace for the EFS Volume
+    Type: String
+  VpcId:
+    Description: The VPC the EFS volume will exist in
+    Type: AWS::EC2::VPC::Id
+  PrivateSubnetId1:
+    Description: The first private subnet the EFS volume will exist in
+    Type: AWS::EC2::Subnet::Id
+  PrivateSubnetId2:
+    Description: The second private subnet the EFS volume will exist in
+    Type: AWS::EC2::Subnet::Id
+  EFSAccessPointUserGroup:    # "8983"
+    Description: The user and group for the EFS Access Point
+    Type: String
+  EFSAccessPointPath:         # "/var/solr"
+    Description: The path for the EFS Access Point
+    Type: String
+
+Resources:
+  EfsSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: !Sub ${Namespace}-efs
+      GroupDescription: !Sub Security Group for ${Namespace} EFS
+      SecurityGroupIngress:
+        - Description: Allow inbound traffic NFS traffic
+          ToPort: 2049
+          FromPort: 2049
+          IpProtocol: tcp
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - Description: Allow outbound NFS traffic
+          ToPort: 2049
+          FromPort: 2049
+          IpProtocol: tcp
+          CidrIp: 0.0.0.0/0
+      VpcId: !Ref 'VpcId'
+
+  # ignore cfn-lint error I3011
+  EfsFileSystem:
+    Type: AWS::EFS::FileSystem
+    Properties:
+      PerformanceMode: generalPurpose
+      FileSystemTags:
+        - Key: Name
+          Value: !Sub ${Namespace}-efs-volume
+      BackupPolicy:
+        Status: ENABLED
+      Encrypted: false
+      LifecyclePolicies:
+        - TransitionToIA: AFTER_30_DAYS
+        - TransitionToPrimaryStorageClass: AFTER_1_ACCESS
+
+  EfsAccessPoint:
+    Type: AWS::EFS::AccessPoint
+    Properties:
+      FileSystemId: !Ref EfsFileSystem
+      PosixUser:
+        Uid: !Ref EFSAccessPointUserGroup
+        Gid: !Ref EFSAccessPointUserGroup
+      RootDirectory:
+        CreationInfo:
+          OwnerGid: !Ref EFSAccessPointUserGroup
+          OwnerUid: !Ref EFSAccessPointUserGroup
+          Permissions: "0755"
+        Path: !Ref EFSAccessPointPath
+
+  EfsMountTarget1:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref EfsFileSystem
+      SubnetId: !Ref PrivateSubnetId1
+      SecurityGroups:
+        - !Ref EfsSecurityGroup
+
+  EfsMountTarget2:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref EfsFileSystem
+      SubnetId: !Ref PrivateSubnetId2
+      SecurityGroups:
+        - !Ref EfsSecurityGroup
+
+  EfsTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${Namespace}-task-role
+      Path: "/service-role/"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ ecs-tasks.amazonaws.com ]
+            Action: [ "sts:AssumeRole" ]
+            Condition:
+              ArnLike:
+                aws:SourceArn:
+                  - !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:*"
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+  EfsTaskPolicy:
+      Type: AWS::IAM::ManagedPolicy
+      Properties:
+        ManagedPolicyName: !Sub ${Namespace}-task-policy
+        Path: "/"
+        Roles: [ !Ref EfsTaskRole ]
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Sid: EFSAccess
+              Effect: Allow
+              Action:
+                - elasticfilesystem:ClientMount
+                - elasticfilesystem:ClientWrite
+                - elasticfilesystem:DescribeMountTargets
+                - elasticfilesystem:DescribeFileSystems
+              Resource: !GetAtt EfsFileSystem.Arn
+
+Outputs:
+  EfsFileSystemId:
+    Description: The ID of the EFS file system
+    Value: !Ref EfsFileSystem
+
+  EfsAccessPointId:
+    Description: The ID of the EFS access point
+    Value: !Ref EfsAccessPoint
+
+  EfsTaskRoleArn:
+    Description: The ARN of the EFS task role
+    Value: !GetAtt EfsTaskRole.Arn

--- a/infrastructure/cinco/templates/efs.yaml
+++ b/infrastructure/cinco/templates/efs.yaml
@@ -87,10 +87,10 @@ Resources:
       SecurityGroups:
         - !Ref EfsSecurityGroup
 
-  EfsTaskRole:
+  EfsReaderRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${Namespace}-task-role
+      RoleName: !Sub ${Namespace}-reader-role
       Path: "/service-role/"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -108,12 +108,12 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
 
-  EfsTaskPolicy:
+  EfsReaderPolicy:
       Type: AWS::IAM::ManagedPolicy
       Properties:
-        ManagedPolicyName: !Sub ${Namespace}-task-policy
+        ManagedPolicyName: !Sub ${Namespace}-reader-policy
         Path: "/"
-        Roles: [ !Ref EfsTaskRole ]
+        Roles: [ !Ref EfsReaderRole ]
         PolicyDocument:
           Version: 2012-10-17
           Statement:
@@ -121,9 +121,45 @@ Resources:
               Effect: Allow
               Action:
                 - elasticfilesystem:ClientMount
-                - elasticfilesystem:ClientWrite
                 - elasticfilesystem:DescribeMountTargets
                 - elasticfilesystem:DescribeFileSystems
+              Resource: !GetAtt EfsFileSystem.Arn
+
+  EfsWriterRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${Namespace}-writer-role
+      Path: "/service-role/"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ ecs-tasks.amazonaws.com ]
+            Action: [ "sts:AssumeRole" ]
+            Condition:
+              ArnLike:
+                aws:SourceArn:
+                  - !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:*"
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        - !Ref EfsReaderPolicy
+
+  EfsWriterPolicy:
+      Type: AWS::IAM::ManagedPolicy
+      Properties:
+        ManagedPolicyName: !Sub ${Namespace}-writer-policy
+        Path: "/"
+        Roles: [ !Ref EfsWriterRole ]
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Sid: EFSAccess
+              Effect: Allow
+              Action:
+                - elasticfilesystem:ClientWrite
               Resource: !GetAtt EfsFileSystem.Arn
 
 Outputs:
@@ -135,6 +171,10 @@ Outputs:
     Description: The ID of the EFS access point
     Value: !Ref EfsAccessPoint
 
-  EfsTaskRoleArn:
+  EfsReaderRoleArn:
     Description: The ARN of the EFS task role
-    Value: !GetAtt EfsTaskRole.Arn
+    Value: !GetAtt EfsReaderRole.Arn
+
+  EfsWriterRoleArn:
+    Description: The ARN of the EFS task role
+    Value: !GetAtt EfsWriterRole.Arn

--- a/infrastructure/cinco/templates/rds-postgres.yaml
+++ b/infrastructure/cinco/templates/rds-postgres.yaml
@@ -13,9 +13,6 @@ Parameters:
   SubnetIDs:
     Description: Comma-separated list of subnet IDs
     Type: List<AWS::EC2::Subnet::Id>
-  ApplicationSecurityGroup:
-    Description: The security group for the application - this template allows the RDS instance to be accessed from an application residing in the application security group
-    Type: AWS::EC2::SecurityGroup::Id
 
 
 Resources:
@@ -39,23 +36,12 @@ Resources:
 
   InstanceSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
-    DependsOn: "InstanceSecurityGroup"
     Properties:
       GroupId: !Ref "InstanceSecurityGroup"
       IpProtocol: "tcp"
       FromPort: "0"
       ToPort: "65535"
       SourceSecurityGroupId: !Ref "InstanceSecurityGroup"
-
-  InstanceSecurityGroupApplicationIngress:
-    Type: "AWS::EC2::SecurityGroupIngress"
-    DependsOn: "InstanceSecurityGroup"
-    Properties:
-      GroupId: !Ref "InstanceSecurityGroup"
-      IpProtocol: "tcp"
-      FromPort: "5432"
-      ToPort: "5432"
-      SourceSecurityGroupId: !Ref "ApplicationSecurityGroup"
 
   RDSInstance:
     Type: AWS::RDS::DBInstance


### PR DESCRIPTION
Creates Solr and Solr Writer ECS services talking to the same EFS volume. Limits HTTP(S) access to these services at the security group layer to the groups listed in `sceptre_user_data.HttpAccessList`

Still todo:
- script to create solr cores