### PR TITLE
Cinco DAGS development

### DIFF
--- a/.github/workflows/dags_test.yml
+++ b/.github/workflows/dags_test.yml
@@ -1,0 +1,32 @@
+name: Dags Check
+on:
+
+    pull_request:
+        branches:
+        - main
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v3
+        - name: Set up Python
+          uses: actions/setup-python@v4
+          with:
+            python-version: "3.9"
+
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r dags/requirements.txt
+            pip install apache-airflow boto3
+            pip check
+        - name: Lint dags with ruff
+          run: |
+            pip install ruff
+            ruff check --output-format=github ./dags
+        - name: Test with Pytest
+          run: |
+            pip install pytest
+            mv dags cinco
+            export CONTAINER_EXECUTION_ENVIRONMENT="docker"
+            pytest cinco/dags_tests.py -v

--- a/.github/workflows/dags_test.yml
+++ b/.github/workflows/dags_test.yml
@@ -12,7 +12,7 @@ jobs:
         - name: Set up Python
           uses: actions/setup-python@v4
           with:
-            python-version: "3.9"
+            python-version: "3.11"
 
         - name: Install dependencies
           run: |

--- a/arclight/bin/index-from-s3
+++ b/arclight/bin/index-from-s3
@@ -23,7 +23,7 @@ if [ -z "$SOLR_URL" ]; then
 fi
 
 echo "Downloading Finding Aid ID: $1 to /tmp"
-aws s3 sync s3://$S3_BUCKET/$2 /tmp/$1
+aws s3 sync s3://$S3_BUCKET/media/indexing/$2 /tmp/$1
 
 echo "Indexing Finding Aid ID: $1"
 bundle exec traject -I lib/ \

--- a/cincoctrl/cincoctrl/findingaids/management/commands/poll_sqs.py
+++ b/cincoctrl/cincoctrl/findingaids/management/commands/poll_sqs.py
@@ -25,6 +25,8 @@ class Command(BaseCommand):
         # SQS message structure: MessageId, ReceiptHandle, MD5OfBody,
         #   Body (dict, SNS message)
 
+        self.stdout.write(f"Found {len(sqs_messages)} messages in SQS queue.")
+
         for sqs_message in sqs_messages:
             sns_message = json.loads(sqs_message.pop("Body"))
             # SNS message structure: Type, MessageId, TopicArn, Timestamp,

--- a/dags/.airflowignore
+++ b/dags/.airflowignore
@@ -1,0 +1,1 @@
+dags_test.py

--- a/dags/cincoctrl_operator.py
+++ b/dags/cincoctrl_operator.py
@@ -43,12 +43,12 @@ class CincoCtrlEcsOperator(EcsRunTaskOperator):
         if manage_cmd == "prepare_finding_aid":
             manage_args = [finding_aid_id, s3_key]
 
-        container_name = f"cinco-ctrl-mgmt-{manage_cmd}-{'-'.join(manage_args)}"
+        container_name = "cinco-ctrl-stage-container"
         args = {
             "cluster": "cinco-stage",
             "launch_type": "FARGATE",
             "platform_version": "LATEST",
-            "task_definition": "cinco-ctrl-stage-container",
+            "task_definition": "cinco-ctrl-stage",
             "overrides": {
                 "containerOverrides": [
                     {

--- a/dags/cincoctrl_operator.py
+++ b/dags/cincoctrl_operator.py
@@ -125,7 +125,7 @@ class CincoCtrlDockerOperator(DockerOperator):
 
         container_image = "cincoctrl_local_django"
         container_version = "latest"
-        container_name = f"cincoctrl_local_django-{manage_cmd}-{'-'.join(manage_args)}"
+        container_name = "cincoctrl_local_django-managepy"
 
         args = {
             "image": f"{container_image}:{container_version}",

--- a/dags/cincoctrl_operator.py
+++ b/dags/cincoctrl_operator.py
@@ -63,13 +63,13 @@ class CincoCtrlEcsOperator(EcsRunTaskOperator):
                 ]
             },
             "region": "us-west-2",
-            "awslogs_group": "cinco-ctrl-stage",
-            "awslogs_region": "us-west-2",
-            "awslogs_stream_prefix": "ecs",
-            "reattach": True,
-            "number_logs_exception": 100,
-            "waiter_delay": 10,
-            "waiter_max_attempts": 8640,
+            # "awslogs_group": "/ecs/cinco-ctrl-stage",
+            # "awslogs_region": "us-west-2",
+            # "awslogs_stream_prefix": f"ecs-manage-{manage_cmd}-",
+            # "reattach": True,
+            # "number_logs_exception": 100,
+            # "waiter_delay": 10,
+            # "waiter_max_attempts": 8640,
         }
         args.update(kwargs)
         super().__init__(**args)

--- a/dags/dags_tests.py
+++ b/dags/dags_tests.py
@@ -1,0 +1,17 @@
+import sys
+
+from unittest import TestCase
+
+from airflow.models import DagBag
+
+sys.path.append(".")
+
+DAGS_FOLDER = "."
+
+
+class CincoDagsTest(TestCase):
+    def dag_bag(self):
+        return DagBag(dag_folder=DAGS_FOLDER, include_examples=False)
+
+    def test_no_import_errors(self):
+        assert not self.dag_bag().import_errors

--- a/dags/poll_message_queue.py
+++ b/dags/poll_message_queue.py
@@ -14,7 +14,7 @@ from cinco.cincoctrl_operator import CincoCtrlOperator
     # on_success_callback=notify_dag_success,
 )
 def poll_message_queue():
-    poll_queue = CincoCtrlOperator(
+    poll_queue = CincoCtrlOperator(  # noqa: F841
         task_id="poll_queue",
         manage_cmd="poll_sqs",
         # on_failure_callback=notify_failure,

--- a/infrastructure/cinco/config/dags-deploy.yaml
+++ b/infrastructure/cinco/config/dags-deploy.yaml
@@ -8,6 +8,8 @@ parameters:
   FilePath: dags/.*
 
 sceptre_user_data:
+  CodeBuildPolicies:
+    - arn:aws:iam::777968769372:policy/cinco-dags-sync
   build_spec: |-
     !Sub >-
               version: 0.2

--- a/infrastructure/cinco/config/dags-deploy.yaml
+++ b/infrastructure/cinco/config/dags-deploy.yaml
@@ -1,0 +1,19 @@
+template:
+  path: codebuild.j2
+  type: file
+parameters:
+  GitHubRepo: https://github.com/ucldc/cinco
+  Namespace: cinco-dags-deploy
+  Branch: main
+  FilePath: dags/.*
+
+sceptre_user_data:
+  build_spec: |-
+    !Sub >-
+              version: 0.2
+
+              phases:
+                build:
+                  commands:
+                    - aws s3 sync --exclude="*" --include="*.py" --delete ./dags s3://pad-airflow/dags/cinco/
+                    - aws s3 cp dags/.airflowignore s3://pad-airflow/dags/cinco/dags/.airflowignore

--- a/infrastructure/cinco/config/stage/cincoctrl/build.yaml
+++ b/infrastructure/cinco/config/stage/cincoctrl/build.yaml
@@ -3,12 +3,12 @@ template:
   type: file
 parameters:
   GitHubRepo: https://github.com/ucldc/cinco
-  ECRRepositoryName: cinco-ctrl
   Namespace: cinco-ctrl-stage
   Branch: main
   FilePath: cincoctrl/.*
 
 sceptre_user_data:
+  ECRRepositoryName: cinco-ctrl
   BuildEnvironment:
     - SUBNET_IDS: !environment_variable SUBNET_IDS
   build_spec: |-

--- a/infrastructure/cinco/config/stage/solr/build.yaml
+++ b/infrastructure/cinco/config/stage/solr/build.yaml
@@ -3,12 +3,12 @@ template:
   type: file
 parameters:
   GitHubRepo: https://github.com/ucldc/cinco
-  ECRRepositoryName: cinco-solr
   Namespace: cinco-solr-stage
   Branch: main
   FilePath: Dockerfile.solr|arclight/solr/*
 
 sceptre_user_data:
+  ECRRepositoryName: cinco-solr
   build_spec: |-
     !Sub >-
               version: 0.2

--- a/infrastructure/cinco/templates/codebuild.j2
+++ b/infrastructure/cinco/templates/codebuild.j2
@@ -7,9 +7,6 @@ Parameters:
   GitHubRepo:
     Description: The URL of the GitHub repository to pull code from
     Type: String
-  ECRRepositoryName:
-    Description: The name of the ECR repository to create
-    Type: String
   Namespace:
     Description: The namespace for the CodeBuild project
     Type: String
@@ -27,11 +24,13 @@ Parameters:
   #     env var CODEBUILD_SRC_DIR)
 
 Resources:
+  {% if sceptre_user_data and sceptre_user_data.ECRRepositoryName is defined %}
   ECRRepository:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryName: !Ref ECRRepositoryName
+      RepositoryName: {{ sceptre_user_data.ECRRepositoryName }}
     DeletionPolicy: Retain
+  {% endif %}
 
   CodeBuildRole:
     Type: AWS::IAM::Role
@@ -141,7 +140,9 @@ Resources:
           Status: ENABLED
           StreamName: build
 
+{% if sceptre_user_data and sceptre_user_data.ECRRepositoryName is defined %}
 Outputs:
   ECRRepository:
     Description: The ECR Repository
     Value: !GetAtt ECRRepository.RepositoryUri
+{% endif %}

--- a/infrastructure/cinco/templates/codebuild.j2
+++ b/infrastructure/cinco/templates/codebuild.j2
@@ -37,6 +37,12 @@ Resources:
     Properties:
       RoleName: !Sub ${Namespace}-codebuild
       Path: "/service-role/"
+      {% if sceptre_user_data and sceptre_user_data.CodeBuildPolicies is defined %}
+      {% for policy in sceptre_user_data.CodeBuildPolicies %}
+      ManagedPolicyArns:
+        - {{ policy }}
+      {% endfor %}
+      {% endif %}
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
This PR:
- adds infrastructure to deploy Cinco-related DAGS to our existing MWAA instance. 
- updates the CincoCtrlEcsOperator's container name, task definition, security group, and logging configuration to resolve errors in this environment
- updates the CincoCtrl `manage.py poll_sqs` command to give output even when there are no messages on the queue to process. 

For this update, I made the following resources in clickops: 

- A cinco-dags-sync policy allowing uploads to the bucket where we store our PAD airflow DAGS. I wasn't quite sure if this belonged here in this repository, or with the pad-airflow cloudformation. There is a similar rikolti-dags-sync policy, but I couldn't find it in any of our repositories and I'm not sure if it's part of our existing cloudformation. 
- An addition to the pad airflow mwaa execution role's inline policy allowing logging to the `/ecs/cinco-ctrl-stage:*` log group. There is a similar addition for the nuxeo-merritt atom feed's logging, but this addition was not in the pad-airflow cloudformation. 

These both feel like candidates to address as we pull things into the pad-infrastructure repository. 
