### PR TITLE
fix preview parameter passing 

### DIFF
--- a/dags/arclight_operator.py
+++ b/dags/arclight_operator.py
@@ -73,7 +73,9 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
         task_name = "cinco-arclight-stage"
         container_name = "cinco-arclight-stage-container"
 
-        print(f"ArclightECSOperator called with: {finding_aid_id} {repository_code} {finding_aid_ark} {preview}")
+        print(
+            f"ArclightECSOperator called with: {finding_aid_id} {repository_code} {finding_aid_ark} {preview}"
+        )
 
         command = [
             "bin/index-from-s3",
@@ -135,7 +137,6 @@ class ArcLightDockerOperator(DockerOperator):
         preview,
         **kwargs,
     ):
-
         mounts = [
             Mount(
                 source="/Users/awieliczka/Projects/cinco/arclight/bin",
@@ -144,7 +145,9 @@ class ArcLightDockerOperator(DockerOperator):
             )
         ]
 
-        print(f"ArclightDockerOperator called with: {finding_aid_id} {repository_code} {finding_aid_ark} {preview}")
+        print(
+            f"ArclightDockerOperator called with: {finding_aid_id} {repository_code} {finding_aid_ark} {preview}"
+        )
 
         container_image = "cinco-arclight-indexer"
         container_version = "latest"

--- a/dags/arclight_operator.py
+++ b/dags/arclight_operator.py
@@ -73,6 +73,8 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
         task_name = "cinco-arclight-stage"
         container_name = "cinco-arclight-stage-container"
 
+        print(f"ArclightECSOperator called with: {finding_aid_id} {repository_code} {finding_aid_ark} {preview}")
+
         command = [
             "bin/index-from-s3",
             finding_aid_id,
@@ -80,8 +82,9 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
             repository_code,
             finding_aid_ark,
         ]
-        if preview:
+        if preview == "True":
             command.append("--preview")
+
         args = {
             "cluster": cluster_name,
             "launch_type": "FARGATE",
@@ -132,6 +135,7 @@ class ArcLightDockerOperator(DockerOperator):
         preview,
         **kwargs,
     ):
+
         mounts = [
             Mount(
                 source="/Users/awieliczka/Projects/cinco/arclight/bin",
@@ -139,6 +143,8 @@ class ArcLightDockerOperator(DockerOperator):
                 type="bind",
             )
         ]
+
+        print(f"ArclightDockerOperator called with: {finding_aid_id} {repository_code} {finding_aid_ark} {preview}")
 
         container_image = "cinco-arclight-indexer"
         container_version = "latest"
@@ -150,7 +156,7 @@ class ArcLightDockerOperator(DockerOperator):
             repository_code,
             finding_aid_ark,
         ]
-        if preview:
+        if preview == "True":
             command.append("--preview")
         args = {
             "image": f"{container_image}:{container_version}",


### PR DESCRIPTION
Preview parameter is being passed into airflow correctly but it's not making it to the indexing process correctly.

I'm not 100% sure this fix is correct.

I think what's going on is that it's being cast to a string in `index_finding_aid` then we're testing it here as if it's still a boolean.

`preview="{{ params.preview }}",`

I could be wrong because there might be some airflow-specific magic going on here. I actually wouldn't expect this syntax to print the value of the variable to a string at all which gives me some doubt.

I also added some specific logging to get more info in case this doesn't work.