### PR TITLE
Cincoctrl cleanup

### DIFF
--- a/cincoctrl/cincoctrl/findingaids/signals.py
+++ b/cincoctrl/cincoctrl/findingaids/signals.py
@@ -39,6 +39,12 @@ def pre_save(sender, instance, **kwargs):
             instance.textract_output = ""
 
 
+@receiver(post_save, sender=SupplementaryFile)
+def trigger_reindex(sender, instance, created, **kwargs):
+    if instance.textract_status == "SUCCEEDED" and instance.textract_output:
+        instance.finding_aid.queue_index()
+
+
 @receiver(post_save, sender=JobRun)
 def update_status(sender, instance, created, **kwargs):
     current_status = instance.related_model.status

--- a/cincoctrl/cincoctrl/templates/findingaids/queued.html
+++ b/cincoctrl/cincoctrl/templates/findingaids/queued.html
@@ -12,7 +12,7 @@
         <div class="col-sm-12">
             <h2>{{ object.collection_title }}</h2>
             <div class="alert alert-success" role="alert">
-                <h4 class="alert-heading">Queued for: {% if object.status == "published" %}Publication{% else %}Preview{% endif %}</h4>
+                <h4 class="alert-heading">Queued for: {% if object.status == "queued_publish" %}Publication{% else %}Preview{% endif %}</h4>
             </div>
             <a href="{% url 'findingaids:view_record' object.pk %}">Return to finding aid</a>
         </div>

--- a/cincoctrl/cincoctrl/templates/users/repositories.yml
+++ b/cincoctrl/cincoctrl/templates/users/repositories.yml
@@ -14,5 +14,5 @@
     request_types:
         aeon_web_ead:
             request_url: {{ r.aeon_request_url }}
-            request_mappings: {{ r.aeon_request_mappings|safe }}{% endif %}
+            request_mappings: {{ r.aeon_request_mappings|safe }}ead_url{% endif %}
 {% endfor %}


### PR DESCRIPTION
- Fix ead update view so it can grab the new title correctly (reorg code for less repeating)
- Add ead_url to aeon config, I think this is needed to pass info along
- Make sure confirmation view displays the action that was taken
- Trigger reindex when textract is complete.