### PR TITLE
don't poll failed jobs

### DIFF
--- a/cincoctrl/cincoctrl/airflow_client/management/commands/poll_airflow.py
+++ b/cincoctrl/cincoctrl/airflow_client/management/commands/poll_airflow.py
@@ -13,6 +13,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         triggered_jobs = JobTrigger.objects.filter(dag_run_id__isnull=False).exclude(
             jobrun__status=JobRun.SUCCEEDED,
+            jobrun__status=JobRun.FAILED,
         )
         self.stdout.write(f"Found {triggered_jobs.count()} triggered jobs.")
 


### PR DESCRIPTION
- We're getting a ton of extra indexing histories for failed jobs.  I think this is just an oversight.