### PR TITLE
only poll running jobs

### DIFF
--- a/cincoctrl/cincoctrl/airflow_client/management/commands/poll_airflow.py
+++ b/cincoctrl/cincoctrl/airflow_client/management/commands/poll_airflow.py
@@ -11,8 +11,9 @@ class Command(BaseCommand):
     help = "Poll Airflow API for Dag Run Status Changes."
 
     def handle(self, *args, **kwargs):
-        triggered_jobs = JobTrigger.objects.filter(dag_run_id__isnull=False).exclude(
-            jobrun__status=JobRun.SUCCEEDED,
+        triggered_jobs = JobTrigger.objects.filter(
+            dag_run_id__isnull=False,
+            jobrun__status=JobRun.RUNNING,
         )
         self.stdout.write(f"Found {triggered_jobs.count()} triggered jobs.")
 


### PR DESCRIPTION
- We're getting a ton of indexing histories for failed jobs so only poll the running jobs.  This seems like just an oversight to me.