### PR TITLE
encode utf-8 before writing out file, else it fails

### DIFF
--- a/cincoctrl/cincoctrl/findingaids/management/commands/prepare_finding_aid.py
+++ b/cincoctrl/cincoctrl/findingaids/management/commands/prepare_finding_aid.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
             record = render_to_string(
                 "findingaids/express_record.xml",
                 context={"object": finding_aid.expressrecord},
-            ).encode('utf-8')
+            ).encode("utf-8")
             ead_file = ContentFile(record)
 
         storages["default"].save(

--- a/cincoctrl/cincoctrl/findingaids/management/commands/prepare_finding_aid.py
+++ b/cincoctrl/cincoctrl/findingaids/management/commands/prepare_finding_aid.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
             record = render_to_string(
                 "findingaids/express_record.xml",
                 context={"object": finding_aid.expressrecord},
-            )
+            ).encode('utf-8')
             ead_file = ContentFile(record)
 
         storages["default"].save(


### PR DESCRIPTION
- encode record express output as utf-8 before writing to file.  s3 fails to write if there are unicode characters otherwise.