### PR TITLE
fix so triggers without job run objects can be updated

### DIFF
--- a/cincoctrl/cincoctrl/airflow_client/management/commands/poll_airflow.py
+++ b/cincoctrl/cincoctrl/airflow_client/management/commands/poll_airflow.py
@@ -1,5 +1,6 @@
 import botocore
 from django.core.management.base import BaseCommand
+from django.db.models import Q
 
 from cincoctrl.airflow_client.exceptions import MWAAAPIError
 from cincoctrl.airflow_client.models import JobRun
@@ -12,8 +13,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         triggered_jobs = JobTrigger.objects.filter(
-            dag_run_id__isnull=False,
-            jobrun__status=JobRun.RUNNING,
+            dag_run_id__isnull=False
+        ).exclude(
+            Q(jobrun__status=JobRun.SUCCEEDED) |
+            Q(jobrun_status=JobRun.FAILED)
         )
         self.stdout.write(f"Found {triggered_jobs.count()} triggered jobs.")
 

--- a/cincoctrl/cincoctrl/airflow_client/management/commands/poll_airflow.py
+++ b/cincoctrl/cincoctrl/airflow_client/management/commands/poll_airflow.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
         triggered_jobs = JobTrigger.objects.filter(
             dag_run_id__isnull=False,
         ).exclude(
-            Q(jobrun__status=JobRun.SUCCEEDED) | Q(jobrun_status=JobRun.FAILED)
+            Q(jobrun__status=JobRun.SUCCEEDED) | Q(jobrun_status=JobRun.FAILED),
         )
         self.stdout.write(f"Found {triggered_jobs.count()} triggered jobs.")
 

--- a/cincoctrl/cincoctrl/airflow_client/management/commands/poll_airflow.py
+++ b/cincoctrl/cincoctrl/airflow_client/management/commands/poll_airflow.py
@@ -13,10 +13,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         triggered_jobs = JobTrigger.objects.filter(
-            dag_run_id__isnull=False
+            dag_run_id__isnull=False,
         ).exclude(
-            Q(jobrun__status=JobRun.SUCCEEDED) |
-            Q(jobrun_status=JobRun.FAILED)
+            Q(jobrun__status=JobRun.SUCCEEDED) | Q(jobrun_status=JobRun.FAILED)
         )
         self.stdout.write(f"Found {triggered_jobs.count()} triggered jobs.")
 


### PR DESCRIPTION
I did mess up the status updating of index jobs with my last PR.  I didn't realize that this is the process that initially creates jobrun objects so jobtriggers that don't have a job run need to be included.