### PR TITLE
increase the textract job polling rate

### DIFF
--- a/dags/poll_message_queue.py
+++ b/dags/poll_message_queue.py
@@ -6,7 +6,7 @@ from cinco.cincoctrl_operator import CincoCtrlOperator
 
 @dag(
     dag_id="poll_message_queue",
-    schedule="@hourly",
+    schedule="*/10 * * * *",
     start_date=datetime(2025, 1, 1),
     catchup=False,
     tags=["cinco"],


### PR DESCRIPTION
Increase the rate that we're polling the textract job status.  With a large number of imports it's getting super behind only processing 10/hour. We may want to dial it back when we have other traffic happening.