### PR TITLE
Fix ead import errors

### DIFF
--- a/cincoctrl/cincoctrl/findingaids/admin.py
+++ b/cincoctrl/cincoctrl/findingaids/admin.py
@@ -20,7 +20,7 @@ class FindingAidAdmin(admin.ModelAdmin):
     inlines = [SupplementaryFileInline]
     search_fields = ["collection_title", "ark"]
     list_display = ("collection_title", "collection_number", "ark", "repository")
-    list_filter = ["repository"]
+    list_filter = ["status"]
 
 
 class ExpressRecordCreatorInline(admin.TabularInline):
@@ -58,6 +58,7 @@ class ExpressRecordAdmin(admin.ModelAdmin):
 @admin.register(SupplementaryFile)
 class SupplementaryFileAdmin(admin.ModelAdmin):
     ordering = ("finding_aid", "order")
+    list_filter = ["textract_status"]
 
 
 @admin.register(ExpressRecordSubject)


### PR DESCRIPTION
- Tweak admin filters
- Fix bug where extref elements without href tags caused an uncaught error
- Fix bug where collection title was too long (this is a temporary fix, I guess we need to change this field to a text field)
- Add a general catch statement so unexpected errors don't abort the entire import