### PR TITLE
set solr commit to false

### DIFF
--- a/arclight/lib/arclight/traject/ead2_config.rb
+++ b/arclight/lib/arclight/traject/ead2_config.rb
@@ -59,7 +59,7 @@ settings do
   provide "date_normalizer", "Arclight::NormalizedDate"
   provide "title_normalizer", "Arclight::NormalizedTitle"
   provide "reader_class_name", "Arclight::Traject::NokogiriNamespacelessReader"
-  provide "solr_writer.commit_on_close", "true"
+  provide "solr_writer.commit_on_close", "false"
   provide "repository", ENV.fetch("REPOSITORY_ID", nil)
   provide "logger", Logger.new($stderr)
   provide "text_reader", "Oac::TextFileReader"


### PR DESCRIPTION
set solr commit to false.

during imports we're getting a lot of index failures because it's unable to commit at the end. queue up indexes and wait for the background process to commit everything.