### PR TITLE
247 preview bugs

### DIFF
--- a/arclight/app/controllers/arclight/repositories_controller.rb
+++ b/arclight/app/controllers/arclight/repositories_controller.rb
@@ -12,7 +12,7 @@ module Arclight
             search_service = Blacklight.repository_class.new(blacklight_config)
             @response = search_service.search(
             q: "level_ssim:Collection repository_ssim:\"#{@repository.name}\"",
-            fq: "preview_ssi:false",
+            fq: "preview_ssi:false", # ensure previewed items don't show it non-search item lists
             rows: 100
             )
             @collections = @response.documents
@@ -32,7 +32,7 @@ module Arclight
             results = search_service.search(
             q: "level_ssim:Collection",
             'facet.field': "repository_ssim",
-            fq: "preview_ssi:false",
+            fq: "preview_ssi:false", # exclude previewed finding aids from collections counts
             rows: 0
             )
             Hash[*results.facet_fields["repository_ssim"]]

--- a/arclight/app/controllers/arclight/repositories_controller.rb
+++ b/arclight/app/controllers/arclight/repositories_controller.rb
@@ -1,0 +1,41 @@
+# Blacklight::Solr::Repository
+
+module Arclight
+    class RepositoriesController < ApplicationController
+        def index
+            @repositories = Arclight::Repository.all
+            load_collection_counts
+        end
+
+        def show
+            @repository = Arclight::Repository.find_by!(slug: params[:id])
+            search_service = Blacklight.repository_class.new(blacklight_config)
+            @response = search_service.search(
+            q: "level_ssim:Collection repository_ssim:\"#{@repository.name}\"",
+            fq: "preview_ssi:false",
+            rows: 100
+            )
+            @collections = @response.documents
+        end
+
+        private
+
+        def load_collection_counts
+            counts = fetch_collection_counts
+            @repositories.each do |repository|
+            repository.collection_count = counts[repository.name] || 0
+            end
+        end
+
+        def fetch_collection_counts
+            search_service = Blacklight.repository_class.new(blacklight_config)
+            results = search_service.search(
+            q: "level_ssim:Collection",
+            'facet.field': "repository_ssim",
+            fq: "preview_ssi:false",
+            rows: 0
+            )
+            Hash[*results.facet_fields["repository_ssim"]]
+        end
+    end
+end

--- a/arclight/app/controllers/catalog_controller.rb
+++ b/arclight/app/controllers/catalog_controller.rb
@@ -22,8 +22,7 @@ class CatalogController < ApplicationController
       'collection.q': "{!terms f=id v=$row._root_}",
       'collection.defType': "lucene",
       'collection.fl': "*",
-      'collection.rows': 1,
-      fq: "preview_ssi:false"
+      'collection.rows': 1
     }
 
     # Sets the indexed Solr field that will display with highlighted matches
@@ -190,6 +189,9 @@ class CatalogController < ApplicationController
     # since we aren't specifying it otherwise.
     config.add_search_field "all_fields", label: "All Fields" do |field|
       field.include_in_simple_select = true
+      field.solr_parameters = {
+        fq: "preview_ssi:false"
+      }
     end
 
     config.add_search_field "within_collection" do |field|
@@ -203,12 +205,18 @@ class CatalogController < ApplicationController
     # so we have Blacklight use the `qt` parameter to invoke them
     config.add_search_field "keyword", label: "Keyword" do |field|
       field.qt = "search" # default
+      field.solr_parameters = {
+        fq: "preview_ssi:false"
+      }
     end
     config.add_search_field "name", label: "Name" do |field|
       field.qt = "search"
       field.solr_parameters = {
         qf:  "${qf_name}",
         pf:  "${pf_name}"
+      }
+      field.solr_parameters = {
+        fq: "preview_ssi:false"
       }
     end
     config.add_search_field "place", label: "Place" do |field|
@@ -217,12 +225,18 @@ class CatalogController < ApplicationController
         qf:  "${qf_place}",
         pf:  "${pf_place}"
       }
+      field.solr_parameters = {
+        fq: "preview_ssi:false"
+      }
     end
     config.add_search_field "subject", label: "Subject" do |field|
       field.qt = "search"
       field.solr_parameters = {
         qf:  "${qf_subject}",
         pf:  "${pf_subject}"
+      }
+      field.solr_parameters = {
+        fq: "preview_ssi:false"
       }
     end
     config.add_search_field "title", label: "Title" do |field|
@@ -231,6 +245,9 @@ class CatalogController < ApplicationController
         qf:  "${qf_title}",
         pf:  "${pf_title}"
       }
+      field.solr_parameters = {
+        fq: "preview_ssi:false"
+      }
     end
     config.add_search_field "container", label: "Container" do |field|
       field.qt = "search"
@@ -238,12 +255,18 @@ class CatalogController < ApplicationController
         qf:  "${qf_container}",
         pf:  "${pf_container}"
       }
+      field.solr_parameters = {
+        fq: "preview_ssi:false"
+      }
     end
     config.add_search_field "identifier", label: "Identifier" do |field|
       field.qt = "search"
       field.solr_parameters = {
         qf:  "${qf_identifier}",
         pf:  "${pf_identifier}"
+      }
+      field.solr_parameters = {
+        fq: "preview_ssi:false"
       }
     end
 

--- a/arclight/config/downloads.yml
+++ b/arclight/config/downloads.yml
@@ -11,15 +11,15 @@
 #
 sample_unitid:
   pdf:
-    href: 'http://example.com/sample.pdf'
+    href: ''
     size: '1.23MB'
   ead:
-    href: 'http://example.com/sample.xml'
+    href: 'https://cinco-stage.s3.amazonaws.com/media/ead/%{eadid}'
     size: 123456
     # size_accessor: 'level'
 default:
   disabled: true
   pdf:
-    template: 'http://example.com/%{unitid}.pdf'
+    template: ''
   ead:
-    template: 'http://example.com/%{unitid}.xml'
+    template: 'https://cinco-stage.s3.amazonaws.com/media/ead/%{eadid}'


### PR DESCRIPTION
- Point XML links to s3 (we probably need to make this an env variable or something, also, on file upload we'll need to make sure the s3 file name is in the eadid field)
- By adding preview=false to the default_solr_query that meant that we were blocking the content list form loading for previewed items.  Instead add the preview=false to all the field-based queries
- Override the repositories controller so that counts and non-search-based item lists don't include previewed items

Previewed items are still showing up in the auto-complete drop-down.  I'm not sure yet how to fix this.