### PR TITLE
374 preview bugs

### DIFF
--- a/arclight/app/controllers/catalog_controller.rb
+++ b/arclight/app/controllers/catalog_controller.rb
@@ -22,7 +22,8 @@ class CatalogController < ApplicationController
       'collection.q': "{!terms f=id v=$row._root_}",
       'collection.defType': "lucene",
       'collection.fl': "*",
-      'collection.rows': 1
+      'collection.rows': 1,
+      fq: "preview_ssi:false"
     }
 
     # Sets the indexed Solr field that will display with highlighted matches
@@ -189,34 +190,22 @@ class CatalogController < ApplicationController
     # since we aren't specifying it otherwise.
     config.add_search_field "all_fields", label: "All Fields" do |field|
       field.include_in_simple_select = true
-      field.solr_parameters = {
-        fq: "preview_ssi:false"
-      }
     end
 
     config.add_search_field "within_collection" do |field|
       field.include_in_simple_select = false
-      field.solr_parameters = {
-        fq: "-level_ssim:Collection"
-      }
     end
 
     # Field-based searches. We have registered handlers in the Solr configuration
     # so we have Blacklight use the `qt` parameter to invoke them
     config.add_search_field "keyword", label: "Keyword" do |field|
       field.qt = "search" # default
-      field.solr_parameters = {
-        fq: "preview_ssi:false"
-      }
     end
     config.add_search_field "name", label: "Name" do |field|
       field.qt = "search"
       field.solr_parameters = {
         qf:  "${qf_name}",
         pf:  "${pf_name}"
-      }
-      field.solr_parameters = {
-        fq: "preview_ssi:false"
       }
     end
     config.add_search_field "place", label: "Place" do |field|
@@ -225,18 +214,12 @@ class CatalogController < ApplicationController
         qf:  "${qf_place}",
         pf:  "${pf_place}"
       }
-      field.solr_parameters = {
-        fq: "preview_ssi:false"
-      }
     end
     config.add_search_field "subject", label: "Subject" do |field|
       field.qt = "search"
       field.solr_parameters = {
         qf:  "${qf_subject}",
         pf:  "${pf_subject}"
-      }
-      field.solr_parameters = {
-        fq: "preview_ssi:false"
       }
     end
     config.add_search_field "title", label: "Title" do |field|
@@ -245,9 +228,6 @@ class CatalogController < ApplicationController
         qf:  "${qf_title}",
         pf:  "${pf_title}"
       }
-      field.solr_parameters = {
-        fq: "preview_ssi:false"
-      }
     end
     config.add_search_field "container", label: "Container" do |field|
       field.qt = "search"
@@ -255,18 +235,12 @@ class CatalogController < ApplicationController
         qf:  "${qf_container}",
         pf:  "${pf_container}"
       }
-      field.solr_parameters = {
-        fq: "preview_ssi:false"
-      }
     end
     config.add_search_field "identifier", label: "Identifier" do |field|
       field.qt = "search"
       field.solr_parameters = {
         qf:  "${qf_identifier}",
         pf:  "${pf_identifier}"
-      }
-      field.solr_parameters = {
-        fq: "preview_ssi:false"
       }
     end
 

--- a/arclight/app/models/concerns/arclight/catalog.rb
+++ b/arclight/app/models/concerns/arclight/catalog.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Arclight
+  ##
+  # Arclight specific methods for the Catalog
+  module Catalog
+    extend ActiveSupport::Concern
+
+    included do
+      before_action only: :index do
+        if (params.dig(:f, :collection) || []).any?(&:blank?)
+          params[:f][:collection].compact_blank!
+          params[:f].delete(:collection) if params[:f][:collection].blank?
+        end
+      end
+
+      before_action only: :hierarchy do
+        blacklight_config.search_state_fields += %i[id limit offset]
+      end
+
+      Blacklight::Configuration.define_field_access :summary_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :background_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :related_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :indexed_terms_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :in_person_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :cite_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :contact_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :component_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :component_indexed_terms_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :terms_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :component_terms_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :group_header_field, Blacklight::Configuration::IndexField
+    end
+
+    def hierarchy
+      # Remove the fq (preview=false) parameter from the hierarchy call
+      # this ensures that that collection contents can be viewed for previewed items
+      blacklight_config.default_solr_params.delete(:fq)
+      @response = search_service.search_results
+    end
+
+    # Overrides blacklight search state so we can exclude some parameters from being passed into the SearchState
+    def search_state
+      @search_state ||= search_state_class.new(params.except('hierarchy', 'nest_path'), blacklight_config, self)
+    end
+  end
+end

--- a/arclight/solr/conf/schema.xml
+++ b/arclight/solr/conf/schema.xml
@@ -299,7 +299,7 @@
 
    <dynamicField name="*_sort" type="alphaNumericSort" indexed="true" stored="false" multiValued="false" />
    <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
-   <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
+   <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="true" multiValued="true" />
 
    <!-- uncomment the following to ignore any fields that don't already match an existing
         field name or dynamic field, rather than reporting them as an error.

--- a/arclight/solr/conf/solrconfig.xml
+++ b/arclight/solr/conf/solrconfig.xml
@@ -305,11 +305,13 @@
     <lst name="suggester">
       <str name="name">mySuggester</str>
       <str name="lookupImpl">AnalyzingInfixLookupFactory</str>
+      <str name="dictionaryImpl">DocumentDictionaryFactory</str>
       <str name="indexPath">suggester_infix_dir</str>
       <str name="highlight">false</str>
       <str name="suggestAnalyzerFieldType">text</str>
       <str name="buildOnCommit">true</str>
       <str name="field">suggest</str>
+      <str name="contextField">preview_ssi</str>
     </lst>
   </searchComponent>
 
@@ -318,6 +320,7 @@
       <str name="suggest">true</str>
       <str name="suggest.count">5</str>
       <str name="suggest.dictionary">mySuggester</str>
+      <str name="suggest.cfq">false</str>
     </lst>
     <arr name="components">
       <str>suggest</str>


### PR DESCRIPTION
- go back to including preview=false in the default solr query.  This was causing problems with facet-only queries
- Override settings passed into the hierarchy call so that it contents can be viewed for previewed items.
- Change auto-complete settings so previewed items aren't included. In order to use a contextField filter the dictionary implementation and the stored status of the suggest field had to change.