### PR TITLE
DAGs: add stage vs. prod switch for cincoctrl op & arclight op

### DIFF
--- a/cincoctrl/config/settings/production.py
+++ b/cincoctrl/config/settings/production.py
@@ -53,13 +53,13 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-ssl-redirect
 SECURE_SSL_REDIRECT = env.bool("DJANGO_SECURE_SSL_REDIRECT", default=False)
 # https://docs.djangoproject.com/en/dev/ref/settings/#session-cookie-secure
-SESSION_COOKIE_SECURE = True
+# SESSION_COOKIE_SECURE = True  # TODO: AW - uncomment this once you have enabled HTTPS
 # https://docs.djangoproject.com/en/dev/ref/settings/#session-cookie-name
-SESSION_COOKIE_NAME = "__Secure-sessionid"
+# SESSION_COOKIE_NAME = "__Secure-sessionid"  # TODO: AW - uncomment this once you have enabled HTTPS
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-secure
-CSRF_COOKIE_SECURE = True
+# CSRF_COOKIE_SECURE = True  # TODO: AW - uncomment this once you have enabled HTTPS
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-name
-CSRF_COOKIE_NAME = "__Secure-csrftoken"
+# CSRF_COOKIE_NAME = "__Secure-csrftoken"  # TODO: AW - uncomment this once you have enabled HTTPS
 # https://docs.djangoproject.com/en/dev/topics/security/#ssl-https
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-hsts-seconds
 # TODO: set this to 60 seconds first and then to 518400 once you prove the former works

--- a/dags/arclight_operator.py
+++ b/dags/arclight_operator.py
@@ -29,19 +29,19 @@ def get_stack_outputs(stack_name):
     return {output["OutputKey"]: output["OutputValue"] for output in cf_outputs}
 
 
-def get_log_group():
+def get_log_group(stack_name="stage"):
     """
     get the log group name for the arclight container
     """
-    outputs = get_stack_outputs("cinco-stage-arclight-app")
+    outputs = get_stack_outputs(f"cinco-{stack_name}-arclight-app")
     return outputs["LogGroup"]
 
 
-def get_solr_writer_url():
+def get_solr_writer_url(stack_name="stage"):
     """
     get the url of the solr writer from the cloudformation stack
     """
-    outputs = get_stack_outputs("cinco-stage-solr-solr")
+    outputs = get_stack_outputs(f"cinco-{stack_name}-solr-solr")
     return f"http://{outputs['LoadBalancerDNS']}/solr/arclight"
 
 
@@ -133,7 +133,7 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
         # get_awsvpc_config() when the operator is actually run.
         self.network_configuration = {"awsvpcConfiguration": get_awsvpc_config()}
         self.overrides["containerOverrides"][0]["environment"] = [
-            {"name": "SOLR_WRITER", "value": get_solr_writer_url()}
+            {"name": "SOLR_WRITER", "value": get_solr_writer_url("stage")}
         ]
         return super().execute(context)
 

--- a/dags/arclight_operator.py
+++ b/dags/arclight_operator.py
@@ -69,17 +69,22 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
         finding_aid_ark=None,
         eadid=None,
         preview=None,
-        version="stage",
+        cinco_environment="stage",
         **kwargs,
     ):
-        if version == "prod":
-            cluster_name = "cinco-prod"
-            task_name = "cinco-arclight-prod"
-            container_name = "cinco-arclight-prod-container"
+        if cinco_environment == "prd":
+            container_name = "cinco-arclight-prd-container"
+            # TODO: specify task definition revision? how?
+            ecs_names = {
+                "cluster": "cinco-prd",
+                "task_definition": "cinco-arclight-prd",
+            }
         else:  # default to stage
-            cluster_name = "cinco-stage"
-            task_name = "cinco-arclight-stage"
             container_name = "cinco-arclight-stage-container"
+            ecs_names = {
+                "cluster": "cinco-stage",
+                "task_definition": "cinco-arclight-stage",
+            }
 
         command = []
         if arclight_command == "index-from-s3":
@@ -99,10 +104,8 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
             ]
 
         args = {
-            "cluster": cluster_name,
             "launch_type": "FARGATE",
             "platform_version": "LATEST",
-            "task_definition": task_name,
             "overrides": {
                 "containerOverrides": [
                     {
@@ -112,14 +115,15 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
                 ]
             },
             "region": "us-west-2",
-            "awslogs_group": f"/ecs/{task_name}",
-            "awslogs_stream_prefix": f"ecs/{container_name}",
-            "awslogs_region": "us-west-2",
-            "reattach": True,
-            "number_logs_exception": 100,
-            "waiter_delay": 10,
-            "waiter_max_attempts": 8640,
+            # "awslogs_group": f"/ecs/{task_name}",
+            # "awslogs_stream_prefix": f"ecs/{container_name}",
+            # "awslogs_region": "us-west-2",
+            # "reattach": True,
+            # "number_logs_exception": 100,
+            # "waiter_delay": 10,
+            # "waiter_max_attempts": 8640,
         }
+        args.update(ecs_names)
         args.update(kwargs)
         super().__init__(**args)
 
@@ -148,7 +152,7 @@ class ArcLightDockerOperator(DockerOperator):
         finding_aid_ark=None,
         eadid=None,
         preview=None,
-        version="stage",
+        cinco_environment="dev",
         **kwargs,
     ):
         mounts = [

--- a/dags/arclight_operator.py
+++ b/dags/arclight_operator.py
@@ -69,11 +69,17 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
         finding_aid_ark=None,
         eadid=None,
         preview=None,
+        version="stage",
         **kwargs,
     ):
-        cluster_name = "cinco-stage"
-        task_name = "cinco-arclight-stage"
-        container_name = "cinco-arclight-stage-container"
+        if version == "prod":
+            cluster_name = "cinco-prod"
+            task_name = "cinco-arclight-prod"
+            container_name = "cinco-arclight-prod-container"
+        else:  # default to stage
+            cluster_name = "cinco-stage"
+            task_name = "cinco-arclight-stage"
+            container_name = "cinco-arclight-stage-container"
 
         command = []
         if arclight_command == "index-from-s3":
@@ -142,6 +148,7 @@ class ArcLightDockerOperator(DockerOperator):
         finding_aid_ark=None,
         eadid=None,
         preview=None,
+        version="stage",
         **kwargs,
     ):
         mounts = [

--- a/dags/bulk_index_finding_aids.py
+++ b/dags/bulk_index_finding_aids.py
@@ -44,15 +44,15 @@ def bulk_index_finding_aids():
         task_id="bulk_index_task",
         s3_key="{{ params.s3_key }}",
         arclight_command="bulk-index-from-s3",
-        version="{{ params.version }}",
+        cinco_environment="{{ params.cinco_environment }}",
         # on_failure_callback=notify_failure,
         # on_success_callback=notify_success
     )
 
     @task()
-    def cleanup_s3(s3_key, version="stage"):
+    def cleanup_s3(s3_key, cinco_environment="stage"):
         s3 = boto3.resource("s3")
-        if version == "prod":
+        if cinco_environment == "prd":
             bucket_name = Variable.get("CINCO_S3_BUCKET_PROD")
         else:
             bucket_name = Variable.get("CINCO_S3_BUCKET_STAGE")
@@ -62,7 +62,9 @@ def bulk_index_finding_aids():
         delete_results = bucket.objects.filter(Prefix=prefix).delete()
         print(delete_results)
 
-    bulk_index_task >> cleanup_s3("{{ params.s3_key }}", version="{{ params.version }}")
+    bulk_index_task >> cleanup_s3(
+        "{{ params.s3_key }}", cinco_environment="{{ params.cinco_environment }}"
+    )
 
 
 bulk_index_finding_aids = bulk_index_finding_aids()

--- a/dags/bulk_index_finding_aids.py
+++ b/dags/bulk_index_finding_aids.py
@@ -28,11 +28,11 @@ from cinco.arclight_operator import ArcLightOperator
             type="string",
             description="The s3_key where all the indexable finding aids are stored",
         ),
-        "version": Param(
+        "cinco_environment": Param(
             "stage",
             type="enum",
-            enum=["stage", "prod"],
-            description="The version of ArcLight to run",
+            enum=["stage", "prd"],
+            description="The Arclight environment to run",
         ),
     },
     tags=["cinco"],

--- a/dags/cincoctrl_operator.py
+++ b/dags/cincoctrl_operator.py
@@ -39,7 +39,7 @@ class CincoCtrlEcsOperator(EcsRunTaskOperator):
         finding_aid_id=None,
         s3_key=None,
         repository_id=None,
-        version="stage",
+        cinco_environment="stage",
         **kwargs,
     ):
         manage_args = []
@@ -58,11 +58,12 @@ class CincoCtrlEcsOperator(EcsRunTaskOperator):
                 s3_key,
             ]
 
-        if version == "prod":
-            container_name = "cinco-ctrl-prod-container"
+        if cinco_environment == "prd":
+            container_name = "cinco-ctrl-prd-container"
+            # TODO: specify task definition revision? how?
             ecs_names = {
-                "cluster": "cinco-prod",
-                "task_definition": "cinco-ctrl-prod",
+                "cluster": "cinco-prd",
+                "task_definition": "cinco-ctrl-prd",
             }
         else:  # default to stage
             container_name = "cinco-ctrl-stage-container"
@@ -70,7 +71,6 @@ class CincoCtrlEcsOperator(EcsRunTaskOperator):
                 "cluster": "cinco-stage",
                 "task_definition": "cinco-ctrl-stage",
             }
-        container_name = "cinco-ctrl-stage-container"
         args = {
             "launch_type": "FARGATE",
             "platform_version": "LATEST",
@@ -131,7 +131,7 @@ class CincoCtrlDockerOperator(DockerOperator):
         finding_aid_id=None,
         s3_key=None,
         repository_id=None,
-        version="stage",
+        cinco_environment="dev",
         **kwargs,
     ):
         manage_args = []

--- a/dags/cincoctrl_operator.py
+++ b/dags/cincoctrl_operator.py
@@ -34,7 +34,13 @@ def get_stack(stack_name: str):
 
 class CincoCtrlEcsOperator(EcsRunTaskOperator):
     def __init__(
-        self, manage_cmd, finding_aid_id=None, s3_key=None, repository_id=None, **kwargs
+        self,
+        manage_cmd,
+        finding_aid_id=None,
+        s3_key=None,
+        repository_id=None,
+        version="stage",
+        **kwargs,
     ):
         manage_args = []
         if manage_cmd == "prepare_finding_aid":
@@ -52,12 +58,22 @@ class CincoCtrlEcsOperator(EcsRunTaskOperator):
                 s3_key,
             ]
 
+        if version == "prod":
+            container_name = "cinco-ctrl-prod-container"
+            ecs_names = {
+                "cluster": "cinco-prod",
+                "task_definition": "cinco-ctrl-prod",
+            }
+        else:  # default to stage
+            container_name = "cinco-ctrl-stage-container"
+            ecs_names = {
+                "cluster": "cinco-stage",
+                "task_definition": "cinco-ctrl-stage",
+            }
         container_name = "cinco-ctrl-stage-container"
         args = {
-            "cluster": "cinco-stage",
             "launch_type": "FARGATE",
             "platform_version": "LATEST",
-            "task_definition": "cinco-ctrl-stage",
             "overrides": {
                 "containerOverrides": [
                     {
@@ -80,6 +96,7 @@ class CincoCtrlEcsOperator(EcsRunTaskOperator):
             # "waiter_delay": 10,
             # "waiter_max_attempts": 8640,
         }
+        args.update(ecs_names)
         args.update(kwargs)
         super().__init__(**args)
 
@@ -109,7 +126,13 @@ class CincoCtrlEcsOperator(EcsRunTaskOperator):
 
 class CincoCtrlDockerOperator(DockerOperator):
     def __init__(
-        self, manage_cmd, finding_aid_id=None, s3_key=None, repository_id=None, **kwargs
+        self,
+        manage_cmd,
+        finding_aid_id=None,
+        s3_key=None,
+        repository_id=None,
+        version="stage",
+        **kwargs,
     ):
         manage_args = []
         if manage_cmd == "prepare_finding_aid":

--- a/dags/index_finding_aid.py
+++ b/dags/index_finding_aid.py
@@ -31,11 +31,11 @@ from cinco.arclight_operator import ArcLightOperator
         "preview": Param(
             "publish", type="string", description="Either preview or publish"
         ),
-        "version": Param(
+        "cinco_environment": Param(
             "stage",
             type="enum",
-            enum=["stage", "prod"],
-            description="The version of CincoCtrl and ArcLight to run",
+            enum=["stage", "prd"],
+            description="The CincoCtrl and ArcLight environment to run",
         ),
     },
     tags=["cinco"],
@@ -57,7 +57,7 @@ def index_finding_aid():
         manage_cmd="prepare_finding_aid",
         finding_aid_id="{{ params.finding_aid_id }}",
         s3_key=s3_key,
-        version="{{ params.version }}",
+        cinco_environment="{{ params.cinco_environment }}",
         # on_failure_callback=notify_failure,
         # on_success_callback=notify_success
     )
@@ -72,16 +72,16 @@ def index_finding_aid():
         finding_aid_ark="{{ params.finding_aid_ark }}",
         eadid="{{ params.eadid }}",
         preview="{{ params.preview }}",
-        version="{{ params.version }}",
+        cinco_environment="{{ params.cinco_environment }}",
         # on_failure_callback=notify_failure,
         # on_success_callback=notify_success
     )
 
     @task()
-    def cleanup_s3(s3_key, version="stage"):
+    def cleanup_s3(s3_key, cinco_environment="stage"):
         s3 = boto3.resource("s3")
-        if version == "prod":
-            bucket_name = Variable.get("CINCO_S3_BUCKET_PROD")
+        if cinco_environment == "prd":
+            bucket_name = Variable.get("CINCO_S3_BUCKET_PRD")
         else:
             bucket_name = Variable.get("CINCO_S3_BUCKET_STAGE")
         prefix = f"media/{s3_key}"
@@ -94,7 +94,7 @@ def index_finding_aid():
         s3_key
         >> prepare_finding_aid
         >> index_finding_aid_task
-        >> cleanup_s3(s3_key, version="{{ params.version }}")
+        >> cleanup_s3(s3_key, cinco_environment="{{ params.cinco_environment }}")
     )
 
 

--- a/dags/poll_airflow_api.py
+++ b/dags/poll_airflow_api.py
@@ -17,7 +17,7 @@ def cinco_poll_airflow_api():
     poll_airflow = CincoCtrlOperator(  # noqa: F841
         task_id="poll_airflow",
         manage_cmd="poll_airflow",
-        version="stage",
+        cinco_environment="stage",
         trigger_rule="always",
         # on_failure_callback=notify_failure,
         # on_success_callback=notify_success
@@ -26,7 +26,7 @@ def cinco_poll_airflow_api():
     # poll_airflow_prod = CincoCtrlOperator(
     #     task_id="poll_airflow_prod",
     #     manage_cmd="poll_airflow",
-    #     version="prod",
+    #     cinco_environment="prd",
     #     trigger_rule="always"
     #     # on_failure_callback=notify_failure,
     #     # on_success_callback=notify_success

--- a/dags/poll_airflow_api.py
+++ b/dags/poll_airflow_api.py
@@ -23,15 +23,15 @@ def cinco_poll_airflow_api():
         # on_success_callback=notify_success
     )
     # Uncomment when we have production architecture
-    # poll_airflow_prod = CincoCtrlOperator(
-    #     task_id="poll_airflow_prod",
-    #     manage_cmd="poll_airflow",
-    #     cinco_environment="prd",
-    #     trigger_rule="always"
-    #     # on_failure_callback=notify_failure,
-    #     # on_success_callback=notify_success
-    # )
-    # poll_airflow >> poll_airflow_prod
+    poll_airflow_from_prod = CincoCtrlOperator(
+        task_id="poll_airflow_from_prod",
+        manage_cmd="poll_airflow",
+        cinco_environment="prd",
+        trigger_rule="always",
+        # on_failure_callback=notify_failure,
+        # on_success_callback=notify_success
+    )
+    poll_airflow >> poll_airflow_from_prod
 
 
 cinco_poll_airflow_api = cinco_poll_airflow_api()

--- a/dags/poll_airflow_api.py
+++ b/dags/poll_airflow_api.py
@@ -17,9 +17,21 @@ def cinco_poll_airflow_api():
     poll_airflow = CincoCtrlOperator(  # noqa: F841
         task_id="poll_airflow",
         manage_cmd="poll_airflow",
+        version="stage",
+        trigger_rule="always",
         # on_failure_callback=notify_failure,
         # on_success_callback=notify_success
     )
+    # Uncomment when we have production architecture
+    # poll_airflow_prod = CincoCtrlOperator(
+    #     task_id="poll_airflow_prod",
+    #     manage_cmd="poll_airflow",
+    #     version="prod",
+    #     trigger_rule="always"
+    #     # on_failure_callback=notify_failure,
+    #     # on_success_callback=notify_success
+    # )
+    # poll_airflow >> poll_airflow_prod
 
 
 cinco_poll_airflow_api = cinco_poll_airflow_api()

--- a/dags/poll_message_queue.py
+++ b/dags/poll_message_queue.py
@@ -17,7 +17,7 @@ def poll_message_queue():
     poll_queue = CincoCtrlOperator(  # noqa: F841
         task_id="poll_queue",
         manage_cmd="poll_sqs",
-        version="stage",
+        cinco_environment="stage",
         trigger_rule="always",
         # on_failure_callback=notify_failure,
         # on_success_callback=notify_success
@@ -26,7 +26,7 @@ def poll_message_queue():
     # poll_queue_prod = CincoCtrlOperator(
     #     task_id="poll_queue_prod",
     #     manage_cmd="poll_sqs",
-    #     version="prod",
+    #     cinco_environment="prd",
     #     trigger_rule="always",
     #     # on_failure_callback=notify_failure,
     #     # on_success_callback=notify_success

--- a/dags/poll_message_queue.py
+++ b/dags/poll_message_queue.py
@@ -17,9 +17,21 @@ def poll_message_queue():
     poll_queue = CincoCtrlOperator(  # noqa: F841
         task_id="poll_queue",
         manage_cmd="poll_sqs",
+        version="stage",
+        trigger_rule="always",
         # on_failure_callback=notify_failure,
         # on_success_callback=notify_success
     )
+    # Uncomment when we have production architecture
+    # poll_queue_prod = CincoCtrlOperator(
+    #     task_id="poll_queue_prod",
+    #     manage_cmd="poll_sqs",
+    #     version="prod",
+    #     trigger_rule="always",
+    #     # on_failure_callback=notify_failure,
+    #     # on_success_callback=notify_success
+    # )
+    # poll_queue >> poll_queue_prod
 
 
 poll_message_queue = poll_message_queue()

--- a/dags/poll_message_queue.py
+++ b/dags/poll_message_queue.py
@@ -23,15 +23,15 @@ def poll_message_queue():
         # on_success_callback=notify_success
     )
     # Uncomment when we have production architecture
-    # poll_queue_prod = CincoCtrlOperator(
-    #     task_id="poll_queue_prod",
-    #     manage_cmd="poll_sqs",
-    #     cinco_environment="prd",
-    #     trigger_rule="always",
-    #     # on_failure_callback=notify_failure,
-    #     # on_success_callback=notify_success
-    # )
-    # poll_queue >> poll_queue_prod
+    poll_prd_queue = CincoCtrlOperator(
+        task_id="poll_prd_queue",
+        manage_cmd="poll_sqs",
+        cinco_environment="prd",
+        trigger_rule="always",
+        # on_failure_callback=notify_failure,
+        # on_success_callback=notify_success
+    )
+    poll_queue >> poll_prd_queue
 
 
 poll_message_queue = poll_message_queue()

--- a/infrastructure/cinco/config/prd/cincoctrl/app.yaml
+++ b/infrastructure/cinco/config/prd/cincoctrl/app.yaml
@@ -25,7 +25,7 @@ sceptre_user_data:
     - POSTGRES_DB: postgres
     - POSTGRES_USER: {{ var.prd.CINCOCTRL_DB_USERNAME }}
     - POSTGRES_PASSWORD: {{ var.prd.CINCOCTRL_DB_PASSWORD }}
-    - DJANGO_SETTINGS_MODULE: config.settings.stage
+    - DJANGO_SETTINGS_MODULE: config.settings.production
     - DJANGO_SECRET_KEY: {{ var.prd.DJANGO_SECRET_KEY }}
     - DJANGO_ADMIN_URL: {{ var.prd.DJANGO_ADMIN_URL }}
     - DJANGO_AWS_STORAGE_BUCKET_NAME: {{ var.prd.S3_BUCKET_NAME }}


### PR DESCRIPTION
As long as there are no issues with dynamically assigning some of these arguments on `__init__`, I think this actually will take care of all our stack issues (including even reporting back runtime state to CincoCtrl!). I could maybe change the variable names to 'stack_name' instead of 'version'. 