### PR TITLE
use correct capitalization for preview arg

### DIFF
--- a/cincoctrl/cincoctrl/findingaids/management/commands/_prepare_for_indexing.py
+++ b/cincoctrl/cincoctrl/findingaids/management/commands/_prepare_for_indexing.py
@@ -51,7 +51,7 @@ def prepare_finding_aid(finding_aid, s3_key):
         ead_file,
     )
 
-    preview = finding_aid.status == "queued_preview"
+    preview = "false" if finding_aid.status == "queued_preview" else "true"
     indexing_env = (
         f"export FINDING_AID_ID={finding_aid.id}\n"
         f"export REPOSITORY_ID={finding_aid.repository.code}\n"


### PR DESCRIPTION
Arclight is expecting preview to be "true" or "false" but when we stringify directly in python with get "True" and "False"