### PR TITLE
bulk index status and max_records

### DIFF
--- a/cincoctrl/cincoctrl/findingaids/management/commands/bulk_index_finding_aids.py
+++ b/cincoctrl/cincoctrl/findingaids/management/commands/bulk_index_finding_aids.py
@@ -22,9 +22,9 @@ job's working files as the argument.
 """
 
 import logging
+import math
 from datetime import UTC
 from datetime import datetime
-import math
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -134,7 +134,6 @@ class Command(BaseCommand):
                 force_publish=force_publish,
                 s3_key=s3_key,
             )
-
 
 
 def bulk_index_finding_aids(


### PR DESCRIPTION
- add status filter to bulk_index_finding_aids -- it's common to just want to index things that are in an error state but annoying to come up with a giant list of ids
- add max_num_records to bulk_index -- will queue up a bunch of bulk indexing jobs.  large bulk indexes are either failing with out of memory error or command line is killing some of the indexing jobs without completing.
