### PR TITLE
Add EADID parameter to indexing

### DIFF
--- a/arclight/bin/bulk-index-from-s3
+++ b/arclight/bin/bulk-index-from-s3
@@ -40,10 +40,12 @@ for folder in /tmp/$1/*; do
         -i xml -c lib/arclight/traject/ead2_config.rb \
         $folder/finding-aid.xml \
         -s ark=$FINDING_AID_ARK \
+        -s eadid=$EADID \
         -s preview=$PREVIEW &
     unset REPOSITORY_ID
     unset FINDING_AID_ID
     unset FINDING_AID_ARK
+    unset EADID
     unset PREVIEW
     echo "Finished indexing $FINDING_AID_ID"
   fi

--- a/arclight/bin/index-from-s3
+++ b/arclight/bin/index-from-s3
@@ -33,7 +33,7 @@ echo "Setting Repository Code Environment Variable"
 export REPOSITORY_ID=$3
 
 # Preview arg will either be "preview" or "publish"
-if [ "$5" == "preview" ]; then
+if [ "$6" == "preview" ]; then
   echo "Setting Preview Environment Variable"
   export PREVIEW=true
 else
@@ -46,6 +46,7 @@ bundle exec traject -I lib/ \
     -i xml -c lib/arclight/traject/ead2_config.rb \
     /tmp/$1/finding-aid.xml \
     -s ark=$4 \
+    -s eadid=$5 \
     -s preview=$PREVIEW \
 
 unset REPOSITORY_ID

--- a/arclight/lib/arclight/traject/ead2_config.rb
+++ b/arclight/lib/arclight/traject/ead2_config.rb
@@ -94,7 +94,9 @@ end
 to_field "title_filing_ssi", extract_xpath('/ead/eadheader/filedesc/titlestmt/titleproper[@type="filing"]')
 to_field "title_ssm", extract_xpath("/ead/archdesc/did/unittitle")
 to_field "title_tesim", extract_xpath("/ead/archdesc/did/unittitle")
-to_field "ead_ssi", extract_xpath("/ead/eadheader/eadid")
+to_field "ead_ssi" do |_record, accumulator|
+  accumulator << settings.fetch(:eadid, "")
+end
 
 to_field "unitdate_ssm", extract_xpath("/ead/archdesc/did/unitdate")
 to_field "unitdate_bulk_ssim", extract_xpath('/ead/archdesc/did/unitdate[@type="bulk"]')

--- a/cincoctrl/cincoctrl/findingaids/management/commands/_prepare_for_indexing.py
+++ b/cincoctrl/cincoctrl/findingaids/management/commands/_prepare_for_indexing.py
@@ -56,6 +56,7 @@ def prepare_finding_aid(finding_aid, s3_key):
         f"export FINDING_AID_ID={finding_aid.id}\n"
         f"export REPOSITORY_ID={finding_aid.repository.code}\n"
         f"export FINDING_AID_ARK={finding_aid.ark}\n"
+        f"export EADID={finding_aid.eadid}\n"
         f"export PREVIEW={preview}\n"
     )
 

--- a/cincoctrl/cincoctrl/findingaids/models.py
+++ b/cincoctrl/cincoctrl/findingaids/models.py
@@ -110,6 +110,12 @@ class FindingAid(models.Model):
     def public_url(self):
         return f"{settings.ARCLIGHT_URL}{self.ark}"
 
+    @property
+    def eadid(self):
+        if self.ead_file:
+            return self.ead_file.name
+        return self.collection_number
+
     def queue_status(self, *, force_publish=False):
         if force_publish or "publish" in self.status:
             self.status = "queued_publish"
@@ -135,6 +141,7 @@ class FindingAid(models.Model):
                         "finding_aid_id": self.id,
                         "repository_code": self.repository.code,
                         "finding_aid_ark": self.ark,
+                        "eadid": self.eadid,
                         "preview": action,
                     },
                     related_models=[self],

--- a/dags/arclight_operator.py
+++ b/dags/arclight_operator.py
@@ -67,6 +67,7 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
         s3_key=None,
         repository_code=None,
         finding_aid_ark=None,
+        eadid=None,
         preview=None,
         **kwargs,
     ):
@@ -82,6 +83,7 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
                 s3_key,
                 repository_code,
                 finding_aid_ark,
+                eadid,
                 preview,
             ]
         elif arclight_command == "bulk-index-from-s3":
@@ -138,6 +140,7 @@ class ArcLightDockerOperator(DockerOperator):
         s3_key=None,
         repository_code=None,
         finding_aid_ark=None,
+        eadid=None,
         preview=None,
         **kwargs,
     ):
@@ -161,6 +164,7 @@ class ArcLightDockerOperator(DockerOperator):
                 s3_key,
                 repository_code,
                 finding_aid_ark,
+                eadid,
                 preview,
             ]
         elif arclight_command == "bulk-index-from-s3":

--- a/dags/index_finding_aid.py
+++ b/dags/index_finding_aid.py
@@ -23,6 +23,11 @@ from cinco.arclight_operator import ArcLightOperator
         "finding_aid_ark": Param(
             "", type="string", description="The ARK of the Finding Aid"
         ),
+        "eadid": Param(
+            "",
+            type="string",
+            description="If present the filename in s3 elese the collection number",
+        ),
         "preview": Param(
             "publish", type="string", description="Either preview or publish"
         ),
@@ -58,6 +63,7 @@ def index_finding_aid():
         s3_key=s3_key,
         repository_code="{{ params.repository_code }}",
         finding_aid_ark="{{ params.finding_aid_ark }}",
+        eadid="{{ params.eadid }}",
         preview="{{ params.preview }}",
         # on_failure_callback=notify_failure,
         # on_success_callback=notify_success


### PR DESCRIPTION
Pass EADID from cincoctrl to indexing process this should solve 2 problems
1. Ensure that the actual filename in s3 is in the index so Aeon integration will be able to access it
2. Ensure that EADID is not null (which is a showstopper error)