### PR TITLE
Arclight: always search within doc's collection, not document itself

### DIFF
--- a/arclight/app/components/oac/search_document_component.rb
+++ b/arclight/app/components/oac/search_document_component.rb
@@ -12,7 +12,7 @@ module Oac
 
       def search_bar_component
         params = helpers.search_state.params_for_search.except(:qt)
-        params["f[collection][]"] = @document.normalized_title
+        params["f[collection][]"] = @document.collection.normalized_title
 
         Oac::SearchBarComponent.new(
           placeholder_text: "Search this collection",


### PR DESCRIPTION
Search bar on document display searches within the document's collection, not within the document. On component display pages, the search bar was setting `Collection: document`, which wasn't returning any results. 