### PR TITLE
Arclight: add access and use back everywhere

### DIFF
--- a/arclight/app/components/arclight/document_component.html.erb
+++ b/arclight/app/components/arclight/document_component.html.erb
@@ -33,3 +33,5 @@
   <%= helpers.turbo_frame_tag "al-hierarchy-#{document.id}-document", loading: 'lazy', src: helpers.hierarchy_solr_document_path(id: document.id, paginate: true, key: '-document', per_page: 50) %>
 </div>
 <% end %>
+
+<%= access %>


### PR DESCRIPTION
Access and Use displays the combination of collection-level restrictions and component-level restrictions on component pages. We'd like for it to display only the component-level restrictions on component pages, but this will require overwriting the access and use component. For now, add it back on every page. 