### PR TITLE
Chad/arclight/569 static links always at top level

### DIFF
--- a/arclight/app/views/catalog/show.html.erb
+++ b/arclight/app/views/catalog/show.html.erb
@@ -26,7 +26,7 @@
         <% end %>
         <div class="col-sm-auto">
             <span aria-hidden="true"><%= blacklight_icon :printer, classes: 'oac-printer-icon' %></span>
-            <a href="<%= static_finding_aid_path @document.id %>">Printable Guide [HTML]</a>
+            <a href="<%= static_finding_aid_path @document.collection_id %>">Printable Guide [HTML]</a>
         </div>
         <div class="col-sm-auto">
             <%= render 'arclight/requests', document: @document %>

--- a/arclight/config/routes.rb
+++ b/arclight/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   get "/findaid/:id/entire_text/", to: "static_finding_aid#show", as: "static_finding_aid_redirect",  constraints: { id: /ark\:\/.+/ }
 
   get "/findaid/*ark", to: "arks#findaid", constraints: { ark: /ark\:\/.+/ }
-  get "findaid", to:  "static_finding_aid#index"
+  get "/findaid", to:  "static_finding_aid#index"
 
 
   concern :exportable, Blacklight::Routes::Exportable.new

--- a/arclight/config/routes.rb
+++ b/arclight/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   get "/findaid/:id/entire_text/", to: "static_finding_aid#show", as: "static_finding_aid_redirect",  constraints: { id: /ark\:\/.+/ }
 
   get "/findaid/*ark", to: "arks#findaid", constraints: { ark: /ark\:\/.+/ }
+  get "findaid", to:  "static_finding_aid#index"
 
 
   concern :exportable, Blacklight::Routes::Exportable.new


### PR DESCRIPTION
Adds a route to `/findaid` as an index action as is required by the template.

Make sure the link to a static finding aid is always to the full guide, no matter what component level the user is at.

Closes #569 