### PR TITLE
Document component shoud support search state?

### DIFF
--- a/arclight/app/components/static_finding_aid/document_component.rb
+++ b/arclight/app/components/static_finding_aid/document_component.rb
@@ -12,6 +12,10 @@ module StaticFindingAid
       @document_tree
     end
 
+    def search_state
+      {}
+    end
+
     def should_render_field?(field_config, *args)
       true
     end


### PR DESCRIPTION
Was seeing errors in stage like
```
ActionView::Template::Error (undefined method `search_state' for #<StaticFindingAid::DocumentComponent
```
But was unable to reproduce locally. 

So stubbing in a method into the StaticFindingAids  DocumentComponent, as I don't think search_service is actually required there.