### PR TITLE
Add static finding aids as resource

### DIFF
--- a/arclight/app/components/static_finding_aid/document_component.rb
+++ b/arclight/app/components/static_finding_aid/document_component.rb
@@ -13,7 +13,7 @@ module StaticFindingAid
     end
 
     def search_state
-      {}
+      Blacklight::SearchState.new({}, blacklight_config)
     end
 
     def should_render_field?(field_config, *args)

--- a/arclight/app/controllers/arks_controller.rb
+++ b/arclight/app/controllers/arks_controller.rb
@@ -2,4 +2,8 @@ class ArksController < ApplicationController
   def findaid
     redirect_to solr_document_url(params[:ark].to_param)
   end
+
+  def findaid_static
+    redirect_to static_finding_aid_url(params[:ark].to_param)
+  end
 end

--- a/arclight/app/controllers/static_finding_aid_controller.rb
+++ b/arclight/app/controllers/static_finding_aid_controller.rb
@@ -7,6 +7,7 @@ class StaticFindingAidController < CatalogController
     config.header_component = BlankComponent
     config.show.document_component = StaticFindingAid::DocumentComponent
     config.show.access_component = StaticFindingAid::AccessComponent
+    config.track_search_session.storage = false
   end
 
   def show

--- a/arclight/config/routes.rb
+++ b/arclight/config/routes.rb
@@ -20,10 +20,15 @@ Rails.application.routes.draw do
   end
   devise_for :users
 
-  get "/findaid/:id/entire_text/", to: "static_finding_aid#show", as: "static_finding_aid"
-  get "/findaid/:id/entire_text/", to: "static_finding_aid#show", as: "static_finding_aid_redirect",  constraints: { id: /ark\:\/.+/ }
+   resources :static_finding_aid, only: [ :show ], path: "/findaid/static", controller: "static_finding_aid" do
+  end
+
+  # get "/findaid/:id/entire_text/", to: "static_finding_aid#show", as: "static_finding_aid"
+  # get "/findaid/:id/entire_text/", to: "static_finding_aid#show", as: "static_finding_aid_redirect",  constraints: { id: /ark\:\/.+/ }
 
   get "/findaid/*ark", to: "arks#findaid", constraints: { ark: /ark\:\/.+/ }
+  get "/findaid/*ark/entire_text", to: "arks#findaid_static"
+
   get "/findaid", to:  "static_finding_aid#index"
 
 


### PR DESCRIPTION
but also stop tracking searches in the static finding aid controller.

Updates the canonical URL for static guides to findaid/static/ but includes a redirect for `*/entire_text` style path as well.