### PR TITLE
Fix static finding aid order; load all children

### DIFF
--- a/arclight/app/controllers/static_finding_aid_controller.rb
+++ b/arclight/app/controllers/static_finding_aid_controller.rb
@@ -4,10 +4,14 @@ class StaticFindingAidController < CatalogController
   layout "static_catalog_result"
 
   configure_blacklight do |config|
+    config.search_builder_class = StaticFindingAidSearchBuilder
     config.header_component = BlankComponent
+
     config.show.document_component = StaticFindingAid::DocumentComponent
     config.show.access_component = StaticFindingAid::AccessComponent
     config.track_search_session.storage = false
+
+    #
     config[:summary_fields][:creators][:link_to_facet] = false
     config[:component_fields][:creators][:link_to_facet] = false
     config[:indexed_terms_fields][:access_subjects][:link_to_facet] = false

--- a/arclight/app/models/concerns/static_finding_aid/search_behavior.rb
+++ b/arclight/app/models/concerns/static_finding_aid/search_behavior.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Overridden from Arclight and OAC in order to escape IDs
+# and add the hierachy behavior to all searches
+
+require "rsolr"
+
+module StaticFindingAid
+  ##
+  # Customized Search Behavior for Arclight
+  module SearchBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      self.default_processor_chain += %i[
+        add_hierarchy_behavior
+      ]
+    end
+
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+    def add_hierarchy_behavior(solr_parameters)
+      solr_parameters[:fq] ||= []
+      # Escape IDs because arks contain special characters
+      solr_parameters[:fq] << "_nest_parent_:#{RSolr.solr_escape(blacklight_params[:id])}"
+      solr_parameters[:rows] = blacklight_params[:per_page]&.to_i || blacklight_params[:limit]&.to_i || 999_999_999
+      solr_parameters[:start] = blacklight_params[:offset] if blacklight_params[:offset]
+      solr_parameters[:sort] = "sort_isi asc"
+      solr_parameters[:facet] = false
+      solr_parameters.delete("facet.query")
+      solr_parameters.delete("facet.field")
+      solr_parameters.delete("f.repository_ssim.facet.limit")
+      solr_parameters.delete("f.collection_ssim.facet.limit")
+      solr_parameters.delete("f.creator_ssim.facet.limit")
+      solr_parameters.delete("f.names_ssim.facet.limit")
+      solr_parameters.delete("f.geogname_ssim.facet.limit")
+      solr_parameters.delete("f.access_subjects_ssim.facet.limit")
+      solr_parameters.delete("f.level_ssim.facet.limit")
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+  end
+end

--- a/arclight/app/models/static_finding_aid_search_builder.rb
+++ b/arclight/app/models/static_finding_aid_search_builder.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class StaticFindingAidSearchBuilder < Blacklight::SearchBuilder
+  include Blacklight::Solr::SearchBuilderBehavior
+  include StaticFindingAid::SearchBehavior
+end

--- a/arclight/config/application.rb
+++ b/arclight/config/application.rb
@@ -14,7 +14,7 @@ module Arclight
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks arclight oac])
+    config.autoload_lib(ignore: %w[assets tasks arclight])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/arclight/docker-compose.dev.yaml
+++ b/arclight/docker-compose.dev.yaml
@@ -2,6 +2,8 @@ services:
   app:
     image: cinco/app
     pull_policy: never
+    tty: true
+    stdin_open: true
     build:
       context: .
       dockerfile: ./Dockerfile.app.dev

--- a/arclight/lib/oac/finding_aid_tree_node.rb
+++ b/arclight/lib/oac/finding_aid_tree_node.rb
@@ -5,13 +5,11 @@ module Oac
     def initialize(controller, id, has_children: true)
       @controller = controller
       @document = controller.search_service.fetch(::RSolr.solr_escape(id))
-      default_solr_params = @controller.blacklight_config.default_solr_params.dup
-      @controller.blacklight_config.default_solr_params.merge!(
-        { fq: "_nest_parent_:#{::RSolr.solr_escape(id)}", sort: "sort_isi asc", facet: false }
-      )
-      @hierarchy_data = @controller.search_service.search_results.response["docs"].map { |doc| SolrDocument.new(doc) } if has_children || []
-      @controller.blacklight_config.default_solr_params = default_solr_params
-      children
+      results = @controller.search_service.search_results do |builder|
+        builder.blacklight_params[:id] = id
+        builder
+      end
+      @hierarchy_data =  results.response["docs"].map { |doc| SolrDocument.new(doc) } if has_children || []
     end
 
     def children


### PR DESCRIPTION
Use a custom search builder to apply the hierarchy queries to StaticFindingAid controller searches.
Remove all of the facet query params to speed up each request.


Also updates docker compose too allow binding.pry to pass through. 

Stop ignoring the oac directory for auto-loading.

