### PR TITLE
Don't build suggesst on startup of solr

### DIFF
--- a/arclight/solr/conf/solrconfig.xml
+++ b/arclight/solr/conf/solrconfig.xml
@@ -312,6 +312,7 @@
       <str name="buildOnCommit">true</str>
       <str name="field">suggest</str>
       <str name="contextField">preview_ssi</str>
+      <str name="buildOnStartup">false</str>
     </lst>
   </searchComponent>
 


### PR DESCRIPTION
This is slow and is blocking the solr server from coming up.

https://solr.apache.org/guide/solr/latest/query-guide/suggester.html