### PR TITLE
Don't show links to larger static finding aids

### DIFF
--- a/arclight/app/helpers/application_helper.rb
+++ b/arclight/app/helpers/application_helper.rb
@@ -34,4 +34,8 @@ module ApplicationHelper
     end
     collection = ::SolrDocument.new(collection_hash)
   end
+
+  def show_static_finding_aid_link?(document)
+    document.total_component_count.to_i < Rails.application.config.child_component_limit
+  end
 end

--- a/arclight/app/views/catalog/show.html.erb
+++ b/arclight/app/views/catalog/show.html.erb
@@ -24,10 +24,12 @@
             </a>
         </div>
         <% end %>
+        <% if show_static_finding_aid_link? @document %>
         <div class="col-sm-auto">
             <span aria-hidden="true"><%= blacklight_icon :printer, classes: 'oac-printer-icon' %></span>
             <a href="<%= static_finding_aid_path @document.collection_id %>" class="link-underline">Printable guide [HTML]</a>
         </div>
+        <% end %>
         <div class="col-sm-auto">
             <%= render 'arclight/requests', document: @document %>
         </div>

--- a/arclight/config/initializers/static_finding_aid.rb
+++ b/arclight/config/initializers/static_finding_aid.rb
@@ -2,4 +2,4 @@
 # too many to display a static finding aid.
 #
 #
-Rails.application.config.child_component_limit = ENV["CHILD_COMPONENT_LIMIT"] || 15_000
+Rails.application.config.child_component_limit = ENV["CHILD_COMPONENT_LIMIT"] || 800

--- a/arclight/config/initializers/static_finding_aid.rb
+++ b/arclight/config/initializers/static_finding_aid.rb
@@ -1,0 +1,5 @@
+# Set the number of how many child components is
+# too many to display a static finding aid.
+#
+#
+Rails.application.config.child_component_limit = ENV["CHILD_COMPONENT_LIMIT"] || 15_000


### PR DESCRIPTION
Set as an env variable so we can tweak easier.