### PR TITLE
Build process sparkles

### DIFF
--- a/.github/workflows/versioned_release.yml
+++ b/.github/workflows/versioned_release.yml
@@ -1,0 +1,64 @@
+name: 🔖 Versioned Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Version for this release (e.g. v1.2.3)'
+        required: true
+      target_branch:
+        description: 'Branch to release from (default: main)'
+        required: false
+        default: 'main'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # needed to create tags/releases
+
+    steps:
+      - name: Validate version format
+        run: |
+          VERSION="${{ github.event.inputs.release_version }}"
+          if ! echo "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.\+]+)?$'; then
+            echo "❌ Invalid version format: '$VERSION'"
+            echo "Expected format: v1.2.3 or v1.2.3-beta.1"
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.target_branch }}
+
+      - name: Confirm current branch
+        run: git branch --show-current
+
+      - name: Install yq
+        run: |
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
+
+      - name: Make release commit
+        run: |
+          echo "${{ github.event.inputs.release_version }}" > VERSION.txt
+          yq -i ".sceptre_user_data.cinco_version = \"${{ github.event.inputs.release_version }}\"" infrastructure/cinco/config/config.yaml
+
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          git add VERSION.txt infrastructure/cinco/config/config.yaml
+          git commit -am "Release ${{ github.event.inputs.release_version }}"
+          git tag "${{ github.event.inputs.release_version }}"
+          git push origin HEAD
+          git push origin "${{ github.event.inputs.release_version }}"
+
+      - name: Create Release with Auto Release Notes
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ github.event.inputs.release_version }}"
+          name: "${{ github.event.inputs.release_version }}"
+          generateReleaseNotes: true
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/infrastructure/cinco/config/config.yaml
+++ b/infrastructure/cinco/config/config.yaml
@@ -4,3 +4,4 @@ region: us-west-2
 sceptre_user_data_inheritance: merge
 sceptre_user_data:
   stack_parameters: !stack_attr parameters
+  cinco_version: v0.1.6-beta

--- a/infrastructure/cinco/config/prd/arclight/app.yaml
+++ b/infrastructure/cinco/config/prd/arclight/app.yaml
@@ -7,8 +7,9 @@ parameters:
   VpcId: {{ var.prd.VPC_ID }}
   SubnetIDs: {{ var.prd.SUBNET_IDS }}
   ContainerImage: !sub
-    - "{container_image}:v0.1.6-beta"
+    - "{container_image}:{version}"
     - container_image: !stack_output prd/arclight/build.yaml::ECRRepository
+      version: !stack_attr sceptre_user_data.cinco_version
   ContainerPort: 3000
   ContainerCount: 2
   HealthCheckPath: '/'

--- a/infrastructure/cinco/config/prd/arclight/build.yaml
+++ b/infrastructure/cinco/config/prd/arclight/build.yaml
@@ -10,6 +10,7 @@ parameters:
 sceptre_user_data:
   BuildEnvironment:
     - SUBNET_IDS: {{ var.prd.SUBNET_IDS }}
+    - SLACK_HOOK: {{ var.prd.SLACK_HOOK }}
   TriggerFilterGroups:
   # A build is triggered if any filter group evaluates to true, which
   # occurs when all the filters in the group evaluate to true.
@@ -20,6 +21,9 @@ sceptre_user_data:
               version: 0.2
 
               phases:
+                install:
+                  runtime-versions:
+                    python: 3.12
                 build:
                   commands:
                     - TAG=`git describe --tags --abbrev=0`
@@ -36,4 +40,5 @@ sceptre_user_data:
                     - NEW_TASK_DEFINITION=$(echo $TASK_DEFINITION | jq --arg IMAGE "$NEW_IMAGE" '.taskDefinition | .containerDefinitions[0].image = $IMAGE | del(.taskDefinitionArn) | del(.revision) | del(.status) | del(.requiresAttributes) | del(.compatibilities) | del(.registeredAt) | del(.registeredBy)')
                     - REGISTERED_DEFINITION=$(aws ecs register-task-definition --cli-input-json "$NEW_TASK_DEFINITION")
                     - TD_REVISION=$(echo $REGISTERED_DEFINITION | jq -r '.taskDefinition.revision')
+                    - python $CODEBUILD_SRC_DIR/infrastructure/cinco/scripts/message_slack.py --application arclight --cinco_version $TAG --td_family_revisions "$TASK_FAMILY:$TD_REVISION"
                     - aws ecs update-service --cluster cinco-prd --service cinco-arclight-prd-service --task-definition $TASK_FAMILY:$TD_REVISION --force-new-deployment

--- a/infrastructure/cinco/config/prd/cincoctrl/app.yaml
+++ b/infrastructure/cinco/config/prd/cincoctrl/app.yaml
@@ -7,8 +7,9 @@ parameters:
   VpcId: {{ var.prd.VPC_ID }}
   SubnetIDs: {{ var.prd.SUBNET_IDS }}
   ContainerImage: !sub
-    - "{container_image}:v0.1.6-beta"
+    - "{container_image}:{version}"
     - container_image: !stack_output prd/cincoctrl/build.yaml::ECRRepository
+      version: !stack_attr sceptre_user_data.cinco_version
   ContainerPort: 5000
   HealthCheckPath: '/accounts/login/'
   DBInstanceSecurityGroup: !stack_output prd/cincoctrl/db.yaml::RDSSecurityGroup

--- a/infrastructure/cinco/config/prd/cincoctrl/build.yaml
+++ b/infrastructure/cinco/config/prd/cincoctrl/build.yaml
@@ -10,6 +10,7 @@ parameters:
 sceptre_user_data:
   BuildEnvironment:
     - SUBNET_IDS: {{ var.prd.SUBNET_IDS }}
+    - SLACK_HOOK: {{ var.prd.SLACK_HOOK }}
   TriggerFilterGroups:
   # A build is triggered if any filter group evaluates to true, which
   # occurs when all the filters in the group evaluate to true.
@@ -46,4 +47,5 @@ sceptre_user_data:
                     - python $CODEBUILD_SRC_DIR/infrastructure/cinco/scripts/ecs_manage.py --prd --task-definition $TD_REVISION collectstatic --no-input
                     - python $CODEBUILD_SRC_DIR/infrastructure/cinco/scripts/ecs_manage.py --prd --task-definition $TD_REVISION migrate --no-input
                     - echo "Forcing a new deployment of the service to apply changes"
+                    - python $CODEBUILD_SRC_DIR/infrastructure/cinco/scripts/message_slack.py --application cincoctrl --cinco_version $TAG --td_family_revisions "$TASK_FAMILY:$TD_REVISION"
                     - aws ecs update-service --cluster cinco-prd --service cinco-ctrl-prd-service --task-definition $TASK_FAMILY:$TD_REVISION --force-new-deployment

--- a/infrastructure/cinco/config/prd/solr/build.yaml
+++ b/infrastructure/cinco/config/prd/solr/build.yaml
@@ -13,11 +13,16 @@ sceptre_user_data:
   # occurs when all the filters in the group evaluate to true.
     - - Type: EVENT
         Pattern: RELEASED
+  BuildEnvironment:
+    - SLACK_HOOK: {{ var.prd.SLACK_HOOK }}
   build_spec: |-
     !Sub >-
               version: 0.2
 
               phases:
+                install:
+                  runtime-versions:
+                    python: 3.12
                 pre_build:
                   commands:
                     - cd $CODEBUILD_SRC_DIR/arclight
@@ -40,6 +45,7 @@ sceptre_user_data:
                     - TD_REVISION=$(echo $REGISTERED_DEFINITION | jq -r '.taskDefinition.revision')
                     - echo "Please update solr leader service, task definition revision:"
                     - echo $TD_REVISION
+                    - LEADER="cinco-solr-prd:$TD_REVISION"
                     # - aws ecs update-service --cluster cinco-prd --service cinco-solr-prd-service --task-definition $TASK_FAMILY:$TD_REVISION --force-new-deployment
                     ##### Update solr follower 1 task definition #####
                     - echo "Updating solr follower 1 task definition"
@@ -50,6 +56,7 @@ sceptre_user_data:
                     - TD_REVISION=$(echo $REGISTERED_DEFINITION | jq -r '.taskDefinition.revision')
                     - echo "Please update solr follower 1 service, task definition revision:"
                     - echo $TD_REVISION
+                    - FOLLOWER_1="cinco-solr-follower-1-prd:$TD_REVISION"
                     # - aws ecs update-service --cluster cinco-prd --service cinco-solr-follower-1-prd-service --task-definition $TASK_FAMILY:$TD_REVISION --force-new-deployment
                     ##### Update solr follower 2 task definition #####
                     - echo "Updating solr follower 2 task definition"
@@ -60,4 +67,7 @@ sceptre_user_data:
                     - TD_REVISION=$(echo $REGISTERED_DEFINITION | jq -r '.taskDefinition.revision')
                     - echo "Please update solr follower 2 service, task definition revision:"
                     - echo $TD_REVISION
+                    - FOLLOWER_2="cinco-solr-follower-2-prd:$TD_REVISION"
                     # - aws ecs update-service --cluster cinco-prd --service cinco-solr-follower-2-prd-service --task-definition $TASK_FAMILY:$TD_REVISION --force-new-deployment
+                    ###### Message Slack #####
+                    - python $CODEBUILD_SRC_DIR/infrastructure/cinco/scripts/message_slack.py --application solr --cinco_version $TAG --td_family_revisions $LEADER $FOLLOWER_1 $FOLLOWER_2

--- a/infrastructure/cinco/config/prd/solr/solr-follower-1.yaml
+++ b/infrastructure/cinco/config/prd/solr/solr-follower-1.yaml
@@ -7,8 +7,9 @@ parameters:
   VpcId: {{ var.prd.VPC_ID }}
   SubnetIDs: {{ var.prd.SUBNET_IDS }}
   ContainerImage: !sub
-    - "{container_image}:v0.1.6-beta"
+    - "{container_image}:{version}"
     - container_image: !stack_output prd/solr/build.yaml::ECRRepository
+      version: !stack_attr sceptre_user_data.cinco_version
   ContainerPort: 8983
   ContainerCount: 1
   HealthCheckPath: "/solr/arclight/admin/ping"

--- a/infrastructure/cinco/config/prd/solr/solr-follower-2.yaml
+++ b/infrastructure/cinco/config/prd/solr/solr-follower-2.yaml
@@ -7,8 +7,9 @@ parameters:
   VpcId: {{ var.prd.VPC_ID }}
   SubnetIDs: {{ var.prd.SUBNET_IDS }}
   ContainerImage: !sub
-    - "{container_image}:v0.1.6-beta"
+    - "{container_image}:{version}"
     - container_image: !stack_output prd/solr/build.yaml::ECRRepository
+      version: !stack_attr sceptre_user_data.cinco_version
   ContainerPort: 8983
   ContainerCount: 1
   HealthCheckPath: "/solr/arclight/admin/ping"

--- a/infrastructure/cinco/config/prd/solr/solr.yaml
+++ b/infrastructure/cinco/config/prd/solr/solr.yaml
@@ -7,8 +7,9 @@ parameters:
   VpcId: {{ var.prd.VPC_ID }}
   SubnetIDs: {{ var.prd.SUBNET_IDS }}
   ContainerImage: !sub
-    - "{container_image}:v0.1.6-beta"
+    - "{container_image}:{version}"
     - container_image: !stack_output prd/solr/build.yaml::ECRRepository
+      version: !stack_attr sceptre_user_data.cinco_version
   ContainerPort: 8983
   ContainerCount: 1
   HealthCheckPath: "/solr/arclight/admin/ping"

--- a/infrastructure/cinco/scripts/message_slack.py
+++ b/infrastructure/cinco/scripts/message_slack.py
@@ -1,0 +1,203 @@
+import json
+import urllib3
+import os
+import argparse
+
+http = urllib3.PoolManager()
+
+# set as part of the build environment
+AWS_ACCOUNT = os.environ.get("AWS_ACCOUNT_ID", "")
+AWS_REGION = os.environ.get("AWS_DEFAULT_REGION", "")
+SLACK_HOOK = os.environ.get("SLACK_HOOK", "")
+
+td_url_template = "https://{aws_account}.{aws_region}.console.aws.amazon.com/ecs/v2/task-definitions/{td_family}/{td_revision}/containers"
+service_url_template = "https://{aws_account}.{aws_region}.console.aws.amazon.com/ecs/v2/clusters/cinco-prd/services/{service_name}"
+
+
+def craft_slack_message(application, cinco_version, family_revision):
+    if application == "cincoctrl":
+        image = "cinco-ctrl"
+        name = "CincoCtrl prd"
+    elif application == "arclight":
+        image = "arclight"
+        name = "Arclight prd"
+
+    td_family = family_revision.split(":")[0]
+    td_revision = family_revision.split(":")[1]
+    service_name = f"{td_family}-service"
+
+    task_definition_url = td_url_template.format(
+        aws_account=AWS_ACCOUNT,
+        aws_region=AWS_REGION,
+        td_family=td_family,
+        td_revision=td_revision,
+    )
+    service_url = service_url_template.format(
+        aws_account=AWS_ACCOUNT, aws_region=AWS_REGION, service_name=service_name
+    )
+
+    tasks = f"{service_url}/tasks?region={AWS_REGION}"
+    logs = f"{service_url}/logs?region={AWS_REGION}"
+    deployments = f"{service_url}/deployments?region={AWS_REGION}"
+
+    button_links = [("Tasks", tasks), ("Logs", logs), ("Deployments", deployments)]
+    mrkdwn_message = f"*{name}* - deploying image `{image}:{cinco_version}` ; task definition: <{task_definition_url}|{td_family}:{td_revision}>"
+
+    message = {
+        "blocks": [
+            {"type": "section", "text": {"type": "mrkdwn", "text": mrkdwn_message}},
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "text": link[0],
+                        },
+                        "url": link[1],
+                    }
+                    for link in button_links
+                ],
+            },
+        ]
+    }
+
+    return message
+
+
+def craft_solr_slack_message(cinco_version, family_revisions):
+    """
+    Crafts a Slack message for Solr deployments.
+    :param cinco_version: Version of Cinco being deployed.
+    :param family_revisions: Dictionary with family names as keys and their revisions as values.
+    :return: Formatted Slack message.
+    """
+    rich_text_elements = []
+    for family_revision in family_revisions:
+        family, revision = family_revision.split(":")
+        td_url = td_url_template.format(
+            aws_account=AWS_ACCOUNT,
+            aws_region=AWS_REGION,
+            td_family=family,
+            td_revision=revision,
+        )
+        service_name = f"{family}-service"
+        service_url = (
+            service_url_template.format(
+                aws_account=AWS_ACCOUNT,
+                aws_region=AWS_REGION,
+                service_name=service_name,
+            )
+            + "/health?region="
+            + AWS_REGION
+        )
+        rich_text_elements.append(
+            {
+                "type": "rich_text_section",
+                "elements": [
+                    {"type": "link", "url": service_url, "text": service_name},
+                    {"type": "text", "text": " with task definition "},
+                    {"type": "link", "url": td_url, "text": f"{family}:{revision}"},
+                ],
+            }
+        )
+
+    return {
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*CincoSolr prd* - built image `cinco-solr:{cinco_version}` and created task definition revisions.\nPlease update the following services (one at a time, in the following order):",
+                },
+            },
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_list",
+                        "style": "bullet",
+                        "indent": 0,
+                        "elements": rich_text_elements,
+                    }
+                ],
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Indexing will pause during update of cinco-solr-prd-service*",
+                },
+            },
+        ]
+    }
+
+
+def main(application, cinco_version, td_family_revisions):
+    try:
+        if application == "solr":
+            message = craft_solr_slack_message(cinco_version, td_family_revisions)
+            icon_emoji = ":solr:"
+        else:
+            message = craft_slack_message(
+                application, cinco_version, td_family_revisions[0]
+            )
+            icon_emoji = ":hammer_and_wrench:"
+
+        data = {
+            "channel": "#dsc_looks_wrong",
+            "username": "aws-codebuild",
+            "icon_emoji": icon_emoji,
+            "blocks": message["blocks"],
+            "unfurl_links": False,
+            "unfurl_media": False,
+        }
+
+        resp = http.request("POST", SLACK_HOOK, body=json.dumps(data).encode("utf-8"))
+    except Exception as e:
+        print({"error": f"Slack notification failed: {e}"})
+        return
+
+    print(
+        {
+            "message": message,
+            "status_code": resp.status,
+            "response": resp.data,
+        }
+    )
+
+
+if __name__ == "__main__":
+    # add cinco_version, td_revision as required arguments to the script
+    parser = argparse.ArgumentParser(
+        description="Send a slack notification on deployment"
+    )
+
+    parser.add_argument(
+        "--application",
+        type=str,
+        required=True,
+        help="Application that was deployed: cincoctrl, arclight, or solr",
+    )
+    parser.add_argument(
+        "--cinco_version",
+        type=str,
+        required=True,
+        help="Cinco version that was deployed",
+    )
+    parser.add_argument(
+        "--td_family_revisions",
+        nargs="+",
+        required=True,
+        help="Any task definition family revisions that were created",
+    )
+
+    try:
+        args = parser.parse_args()
+        application = args.application
+        cinco_version = args.cinco_version
+        td_family_revisions = args.td_family_revisions
+        main(application, cinco_version, td_family_revisions)
+    except Exception as e:
+        print({"error": f"Argument parsing failed: {e}"})


### PR DESCRIPTION
1) Adds a Github Workflow to create a new version release: 
- workflow uses yq to update `sceptre_user_data.cinco_version` in root sceptre config file
- creates a new commit on the target branch provided (default main)
- tags that branch and pushes both the new commit and the tag up to github
- cuts a new release using auto-generated release notes

2) Adds Slack message output to the codebuild process sending quicklinks to the Service's Tasks, Logs, and Deployments just before beginning --force-new-deployment