### PR TITLE
Update search form to be relative [arclight]

### DIFF
--- a/arclight/app/components/arclight/constraints_component.rb
+++ b/arclight/app/components/arclight/constraints_component.rb
@@ -49,7 +49,7 @@ module Arclight
 
       Oac::SearchBarComponent.new(
         placeholder_text: placeholder_text,
-        url: helpers.search_action_path,
+        url: helpers.search_action_path(only_path: true),
         params: params
       )
     end

--- a/arclight/app/components/arclight/online_content_filter_component.html.erb
+++ b/arclight/app/components/arclight/online_content_filter_component.html.erb
@@ -1,7 +1,7 @@
 <div id="facet-digital_content" class="<%='facet-limit-active' if @document.online_content? %> mb-4">
   <div class="card-body d-flex align-items-center justify-content-between">
       <div class="form-check form-switch">
-      <a href="<%= helpers.search_action_path(f: { collection: [collection_name], access: ['online'] }) %>">
+      <a href="<%= helpers.search_action_path(f: { collection: [collection_name], access: ['online'] }, only_path: true) %>">
         <input class="form-check-input" type="checkbox" id="flexSwitchCheckDefault">
         <label class="form-check-label" for="flexSwitchCheckDefault"><%= t('arclight.views.show.online_content.link_text') %></label>
       </a>

--- a/arclight/app/components/header_component.rb
+++ b/arclight/app/components/header_component.rb
@@ -11,7 +11,9 @@ class HeaderComponent < Arclight::HeaderComponent
         params[:group] = true
         Oac::SearchBarComponent.new(
           placeholder_text: I18n.t("oac.search.placeholder_text"),
-          url: helpers.search_action_path,
+          url: helpers.search_action_path(
+            only_path: true
+          ),
           params: params
           #   autocomplete_path: "/catalog/suggest"
         )

--- a/arclight/app/components/oac/search_document_component.rb
+++ b/arclight/app/components/oac/search_document_component.rb
@@ -16,7 +16,7 @@ module Oac
 
         Oac::SearchBarComponent.new(
           placeholder_text: "Search this collection",
-          url: helpers.search_action_path,
+          url: helpers.search_action_path(only_path: true),
           params: params
         )
       end

--- a/arclight/app/views/catalog/show.html.erb
+++ b/arclight/app/views/catalog/show.html.erb
@@ -19,7 +19,7 @@
         <% if @document.online_content? %>
         <div class="col-sm-auto">
             <span aria-hidden="true"><%= blacklight_icon :online, classes: 'oac-online-content-icon' %></span>
-            <a href="<%= search_action_path(f: { collection: [@document.collection_name], access: ['online'] }) %>" class="link-underline">
+            <a href="<%= search_action_path(f: { collection: [@document.collection_name], access: ['online'] }, only_path: true) %>" class="link-underline">
             <%= t('arclight.collection_info_component.online_items') =%>
             </a>
         </div>

--- a/arclight/app/views/static_pages/home.html.erb
+++ b/arclight/app/views/static_pages/home.html.erb
@@ -21,7 +21,7 @@
             <% params_for_search[:group] = true %>
             <%= render Oac::SearchBarComponent.new(
                 placeholder_text: "Search collection guides",
-                url: search_action_path,
+                url: search_action_path(only_path: true),
                 params: params_for_search
             ) %>
         </div>


### PR DESCRIPTION
oac-stg.cdlib.org is flagged with a security warning in Chrome because the form actions go to http://oac-stg.cdlib.org instead of https://oac-stg.cdlib.org. I had, in another commit, converted `search_action_url` to `search_action_path` and had expected that to be enough for rails to use the relative path. 