### PR TITLE
don't show preview and publish buttons unless necessary

### DIFF
--- a/cincoctrl/cincoctrl/templates/findingaids/record.html
+++ b/cincoctrl/cincoctrl/templates/findingaids/record.html
@@ -70,10 +70,10 @@
               {% else %}
               <a href="{% url 'findingaids:update_ead' object.pk %}" class="btn btn-primary">Update EAD</a>
               {% endif %}
-              {% if object.status == 'started' or object.status == 'previewed' or object.status == 'preview_error' %}
-              <a href="{% url 'findingaids:preview_record' object.pk %}" class="btn btn-primary">Generate Preview</a>
+              {% if object.status == 'started' %}
+               <a href="{% url 'findingaids:preview_record' object.pk %}" class="btn btn-primary">Generate Preview</a>
               {% endif %}
-              {% if object.status == 'previewed' or object.status == 'published' or object.status == 'publish_error' %}
+              {% if object.status == 'previewed' %}
               <a href="{% url 'findingaids:publish_record' object.pk %}" class="btn btn-primary">Publish to OAC</a>
               {% endif %}
         {% if object.status == 'previewed' %}


### PR DESCRIPTION
-  Don't show preview button unless we're in started (this should really never happen but just leave it here for now).
- Only show the publish button when the state is "previewed" so it can be moved to publish