### PR TITLE
Add more cache control to controllers

### DIFF
--- a/arclight/app/controllers/arclight/repositories_controller.rb
+++ b/arclight/app/controllers/arclight/repositories_controller.rb
@@ -3,6 +3,7 @@
 module Arclight
     class RepositoriesController < ApplicationController
         def index
+            expires_in 1.day, public: true
             @repositories = Arclight::Repository.all
             @repository_list = @repositories.group_by { |r| r.name[0] }
             load_collection_counts

--- a/arclight/app/controllers/static_pages_controller.rb
+++ b/arclight/app/controllers/static_pages_controller.rb
@@ -1,6 +1,5 @@
 class StaticPagesController < ApplicationController
-  def about
-  end
+  before_action :set_expiry
 
   def help
   end
@@ -19,5 +18,9 @@ class StaticPagesController < ApplicationController
 
   def home
     @repositories = Arclight::Repository.all
+  end
+
+  def set_expiry
+    expires_in 7.days, public: true
   end
 end


### PR DESCRIPTION
For most, follow the one week headers, but for the institution browse page, just a day so that changes are reflected when updates happen.