### PR TITLE
653 custom indexing

### DIFF
--- a/arclight/app/components/arclight/collection_sidebar_component.html.erb
+++ b/arclight/app/components/arclight/collection_sidebar_component.html.erb
@@ -1,7 +1,7 @@
 <nav class="al-sidebar-navigation-context sidebar-section" aria-labelledby="collection-nav">
   <h2 id="collection-nav"><%= t('arclight.views.show.context_nav.title') %></h2>
   <div class="card p-3 mb-3">
-    <p><b><%= t('arclight.views.show.collection_id') %>:</b> <%= Array(@document["unitid_tesim"]).join(', ') %></p>
+    <p><b><%= t('arclight.views.show.collection_id') %>:</b> <%=  collection_number %></p>
     <p><b><%= t('arclight.views.show.last_indexed') %>:</b> <%= @document.last_indexed.strftime('%F') %></p>
     <p><b>Permalink:</b> <a class="permalink" href="https://oac.cdlib.org/findaid/<%= @document.collection.id %>">https://oac.cdlib.org/findaid/<%= @document.collection.id %></a></p>
   </div>

--- a/arclight/app/components/arclight/collection_sidebar_component.rb
+++ b/arclight/app/components/arclight/collection_sidebar_component.rb
@@ -35,5 +35,13 @@ module Arclight
     def section_anchor(section)
       "##{t("arclight.views.show.sections.#{section}").parameterize}"
     end
+
+    def collection_number
+      if @document.collection["unitid_tesim"].blank?
+        @document.collection["ead_ssi"]
+      else
+        Array(@document.collection["unitid_tesim"]).join(", ")
+      end
+    end
   end
 end

--- a/arclight/lib/arclight/traject/ead2_component_config.rb
+++ b/arclight/lib/arclight/traject/ead2_component_config.rb
@@ -234,7 +234,9 @@ end
 to_field "level_ssm" do |record, accumulator|
   level = record.attribute("level")&.value
   other_level = record.attribute("otherlevel")&.value
-  accumulator << Arclight::LevelLabel.new(level, other_level).to_s
+  level_label =  Arclight::LevelLabel.new(level, other_level).to_s
+  level_label = "File" if level_label == "collection" || level_label == "Collection"
+  accumulator << level_label
 end
 
 to_field "level_ssim" do |_record, accumulator, context|

--- a/arclight/lib/arclight/traject/ead2_config.rb
+++ b/arclight/lib/arclight/traject/ead2_config.rb
@@ -91,9 +91,22 @@ to_field "id" do |record, accumulator|
   end
 end
 
+to_field "unittitle_ssm", extract_xpath("/ead/archdesc/did/unittitle")
+to_field "titleproper_ssm", extract_xpath("/ead/eadheader/filedesc/titlestmt/titleproper")
+
+
 to_field "title_filing_ssi", extract_xpath('/ead/eadheader/filedesc/titlestmt/titleproper[@type="filing"]')
-to_field "title_ssm", extract_xpath("/ead/archdesc/did/unittitle")
-to_field "title_tesim", extract_xpath("/ead/archdesc/did/unittitle")
+to_field "title_ssm" do |_record, accumulator, context|
+  unittitle = context.output_hash["unittitle_ssm"]&.first
+  # if no unittitle fall back to title proper
+  if unittitle.blank?
+    unittitle = context.output_hash["titleproper_ssm"]&.first
+  end
+  accumulator << unittitle
+end
+to_field "title_tesim" do |_record, accumulator, context|
+  accumulator << context.output_hash["title_ssm"]
+end
 to_field "ead_ssi" do |_record, accumulator|
   accumulator << settings.fetch(:eadid, "")
 end

--- a/arclight/lib/arclight/traject/ead2_config.rb
+++ b/arclight/lib/arclight/traject/ead2_config.rb
@@ -340,8 +340,12 @@ to_field "components" do |record, accumulator, context|
 
   child_components.each do |child_component|
     if child_component.content.strip.length > 0
-      output = component_indexer.map_record(child_component)
-      accumulator << output if output.keys.any?
+      begin
+        output = component_indexer.map_record(child_component)
+        accumulator << output if output.keys.any?
+      rescue Arclight::Exceptions::TitleNotFound => e
+        # just ignore this component
+      end
     end
   end
 end


### PR DESCRIPTION
- If unittitle isn't available use titleproper (in indexer)
- If unitid isn't available use eadid (in view)
- Fix bug where unitid/collection number disappears when you view components
- If a component is marked with "level=collection" override to "file"
- Ignore components (and subtrees) that don't have titles or dates