### PR TITLE
Redirect large static guides to the arclight guide page.

### DIFF
--- a/arclight/app/controllers/static_finding_aid_controller.rb
+++ b/arclight/app/controllers/static_finding_aid_controller.rb
@@ -227,7 +227,10 @@ class StaticFindingAidController < ApplicationController
   end
 
   def show
+    @document = search_service.fetch(::RSolr.solr_escape(params[:id]))
+      if !helpers.show_static_finding_aid_link?(@document)
+        redirect_to solr_document_path(@document), status: 302
+      end
     @doc_tree = Oac::FindingAidTreeNode.new(self, params[:id])
-    @document = @doc_tree.document
   end
 end

--- a/arclight/config/initializers/static_finding_aid.rb
+++ b/arclight/config/initializers/static_finding_aid.rb
@@ -2,7 +2,7 @@
 # too many to display a static finding aid.
 #
 #
-Rails.application.config.child_component_limit = ENV["CHILD_COMPONENT_LIMIT"] || 4500
+Rails.application.config.child_component_limit = ENV["CHILD_COMPONENT_LIMIT"] || 1700
 
 #
 Rails.application.config.disallowed_static_guides = [


### PR DESCRIPTION
Lower the threshold for "large"