### PR TITLE
Less solr hits on bad arks URLS

### DIFF
--- a/arclight/config/routes.rb
+++ b/arclight/config/routes.rb
@@ -24,8 +24,10 @@ Rails.application.routes.draw do
    resources :static_finding_aid, only: [ :show ], path: "/findaid/static", controller: "static_finding_aid" do
   end
 
-  get "/findaid/*ark", to: "arks#findaid", constraints: { ark: /ark\:\/.+/ }
+  get "/findaid/*ark/entire_text", to: "arks#findaid_static", constraints: { ark: /ark\:\/[0-9]]{5}\/[0-9a-zA-Z]+/ }
   get "/findaid/*ark/entire_text", to: "arks#findaid_static"
+  get "/findaid/*ark", to: "arks#findaid", constraints: { ark: /ark\:\/.+/ }
+
   get "/findaid/*ark", to: "arks#findaid", constraints: { ark: /ark\:\/.+/ }
 
   get "/findaid", to:  "static_finding_aid#index"

--- a/arclight/config/routes.rb
+++ b/arclight/config/routes.rb
@@ -24,11 +24,16 @@ Rails.application.routes.draw do
    resources :static_finding_aid, only: [ :show ], path: "/findaid/static", controller: "static_finding_aid" do
   end
 
-  get "/findaid/*ark/entire_text", to: "arks#findaid_static", constraints: { ark: /ark\:\/[0-9]]{5}\/[0-9a-zA-Z]+/ }
-  get "/findaid/*ark/entire_text", to: "arks#findaid_static"
-  get "/findaid/*ark", to: "arks#findaid", constraints: { ark: /ark\:\/.+/ }
+  # OAC4 static URLS like /findaid/ark:/13030/ju7h7eed3/entire_text
+  get "/findaid/*ark/entire_text", to: "arks#findaid_static", constraints: { ark: /ark\:\/[0-9]{5}\/[0-9a-zA-Z]+/ }
+  # esacped OAC4 static URLS like /findaid/ark:/13030/ju7h7eed3/entire_text
+  get "/findaid/*ark/entire_text", to: "arks#findaid_static", constraints: { ark: /ark\:%2F[0-9]{5}%2F[0-9a-zA-Z]+/ }
 
-  get "/findaid/*ark", to: "arks#findaid", constraints: { ark: /ark\:\/.+/ }
+  # OAC4 like /findaid/ark:/13030/ju7h7eed3
+  get "/findaid/*ark", to: "arks#findaid", constraints: { ark: /ark\:\/[0-9]{5}\/[0-9a-zA-Z]+/ }
+
+  # Any findaid ark URLs that are not fitting a specific pattern should 404 instead of hitting solr
+  get "/findaid/*ark/*else", to: "errors#not_found", constraints: { ark: /ark\:\/[0-9]{5}\/[0-9a-zA-Z]+/ }
 
   get "/findaid", to:  "static_finding_aid#index"
 

--- a/arclight/spec/requests/institutions_spec.rb
+++ b/arclight/spec/requests/institutions_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Arclight::Repositories", type: :request do
   describe "Does not load pages for non existent institutions" do
       it "returns http not found response" do
         get "/institutions/NOT+REAL+Library"
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:redirect)
       end
     end
 end

--- a/arclight/spec/routing/findaid_spec.rb
+++ b/arclight/spec/routing/findaid_spec.rb
@@ -30,4 +30,13 @@ it "routes unescaped /findaid/ark:/*/entire_text/ to the static_finding_aid cont
       ark: "ark:/13010/sdfsdfsf"
       )
   end
+
+it "routes garbage after ark to the 404 controller" do
+    expect(get("/findaid/ark:/13010/sdfsdfsf/garbage")).to route_to(
+      controller: "errors",
+      action: "not_found",
+      ark: "ark:/13010/sdfsdfsf",
+      else: "garbage"
+      )
+  end
 end


### PR DESCRIPTION
If ARK uRLS are not well formed, go straight to a 404 instead of hitting solr.