### PR TITLE
Removes tracking from search links

### DIFF
--- a/arclight/app/controllers/catalog_controller.rb
+++ b/arclight/app/controllers/catalog_controller.rb
@@ -419,6 +419,8 @@ class CatalogController < ApplicationController
     # Group header values
     config.add_group_header_field "abstract_or_scope", accessor: true, truncate: true, helper_method: :render_html_tags
 
+    # Disable search session tracking
+    config.track_search_session.storage = false
 
 
     ############ OAC CUSTOMIZATIONS #########
@@ -428,30 +430,5 @@ class CatalogController < ApplicationController
     config.index.document_actions.delete(:bookmark)
     config.show.document_actions.delete(:bookmark)
     config.navbar.partials.delete(:bookmark)
-  end
-
-  def show_static
-    @doc_tree = FindingAidTreeNode.new(self, params[:id])
-  end
-end
-
-
-class FindingAidTreeNode
-  attr_reader :data
-
-
-  def method_missing(m, *args, &block)
-    @data.send(m, *args, &block)
-  end
-
-  def initialize(controller, id, has_children: true)
-    @data = controller.search_service.fetch(id)
-    @hierarchy_data = controller.search_service()
-  end
-
-  def children
-    @children ||= @hierarchy_data.map do  |item|
-      FindingAidTreeNode.new(doc.id, has_children: doc.children?)
-    end
   end
 end

--- a/arclight/app/models/concerns/cache_control.rb
+++ b/arclight/app/models/concerns/cache_control.rb
@@ -2,7 +2,7 @@ module CacheControl
   extend ActiveSupport::Concern
 
   included do
-    before_action only: [ :index, :show ] do
+    before_action only: [ :index, :show, :hierarchy ] do
       expires_in 7.days, public: true
     end
   end

--- a/arclight/app/views/layouts/blacklight/base.html.erb
+++ b/arclight/app/views/layouts/blacklight/base.html.erb
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<%= content_tag :html, class: 'no-js', **html_tag_attributes do %>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <!-- Added to disbale turbolinks -->
+     <meta name="turbo-prefetch" content="false">
+
+
+    <title><%= render_page_title %></title>
+    <script>
+      document.querySelector('html').classList.remove('no-js');
+    </script>
+    <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
+    <%= favicon_link_tag %>
+    <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload"  %>
+    <% if defined? Importmap %>
+      <%= javascript_importmap_tags %>
+    <% elsif defined? Propshaft %>
+      <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <% else %>
+      <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+      <script type="module">
+        import githubAutoCompleteElement from 'https://cdn.skypack.dev/@github/auto-complete-element';
+      </script>
+    <% end %>
+
+    <%= csrf_meta_tags %>
+    <%= content_for(:head) %>
+  </head>
+  <body class="<%= render_body_class %>">
+    <%= render blacklight_config.skip_link_component.new do %>
+      <%= content_for(:skip_links) %>
+    <% end %>
+
+    <%= render partial: 'shared/header_navbar' %>
+
+    <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
+      <%= content_for(:container_header) %>
+
+      <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+
+      <div class="row">
+        <%= content_for?(:content) ? yield(:content) : yield %>
+      </div>
+    </main>
+
+    <%= render partial: 'shared/footer' %>
+    <%= render partial: 'shared/modal' %>
+  </body>
+<% end %>

--- a/arclight/config/initializers/deprecation.rb
+++ b/arclight/config/initializers/deprecation.rb
@@ -1,0 +1,4 @@
+require "deprecation"
+Rails.application.config.after_initialize do
+  Deprecation.default_deprecation_behavior = :silence
+end

--- a/arclight/config/initializers/logging.rb
+++ b/arclight/config/initializers/logging.rb
@@ -1,6 +1,8 @@
 Rails.application.configure do
-  config.lograge.enabled = true if Rails.env.production?
+  # removes timestamp before json logs
+  config.logger = ActiveSupport::Logger.new(STDOUT)
 
+  config.lograge.enabled = true if Rails.env.production?
 
   config.lograge.custom_options = lambda do |event|
       { time: Time.now }

--- a/arclight/public/robots.txt
+++ b/arclight/public/robots.txt
@@ -1,1 +1,4 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /search
+Disallow: /view
+Crawl-delay: 5


### PR DESCRIPTION
Turns off tracking from search links.

Disabe Turbo LxiiInks so that pages do not pre-load when a link is voered as tat requires js changes. Maybe we can turn it back on later.

Add caching for hierarchy requests.

Hopefuly silence some deprecation warnings?!?

Removes some leftover cruft static finding aid cruft.

Add a robots.txt too!