### PR TITLE
Add return statements

### DIFF
--- a/arclight/app/controllers/static_finding_aid_controller.rb
+++ b/arclight/app/controllers/static_finding_aid_controller.rb
@@ -243,10 +243,12 @@ class StaticFindingAidController < ApplicationController
       case response
       when Net::HTTPOK
         redirect_to "/static_findaids/#{@document.id}.html"
+        return
       end
 
       if !helpers.show_static_finding_aid_link?(@document)
         redirect_to "/findaid/#{@document.id}"
+        return
       end
 
     @doc_tree = Oac::FindingAidTreeNode.new(self, params[:id])


### PR DESCRIPTION
Without the return statements, Rails tells us:

```
AbstractController::DoubleRenderError (Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like "redirect_to(...); return".):
```