### PR TITLE
update pre-commit-config to exclude repositories config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+        exclude: (^arclight/config/repositories(-stage)?.yml$)
       - id: check-json
       - id: check-toml
       - id: check-xml


### PR DESCRIPTION
Exclude repositories.yml and repositories-stage.yml from end of file fixer (these files, when generated via cincoctrl, include a new line at the bottom). 