### PR TITLE
Switch to less possibly dangerous query

### DIFF
--- a/arclight/bin/remove-from-solr
+++ b/arclight/bin/remove-from-solr
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+set -euo pipefail
+
 # This script takes as an argument the ID of a finding aid
 # and deletes the finding aid from Solr
 
@@ -20,14 +22,14 @@ findaid_id=$1
 escaped_findaidid="${findaid_id//\:/\\\:}"
 escaped_findaidid="${escaped_findaidid//\//\\\/}"
 
-curl -X POST "$SOLR_WRITER/update?commit=true" \
-    -H "Content-Type: text/xml" \
-    --data-binary "<delete><query>id:$escaped_findaidid*</query></delete>"
-
-# alternative delete query
+# Possibly unsafe delete query
 # curl -X POST "$SOLR_WRITER/update?commit=true" \
 #     -H "Content-Type: text/xml" \
-#     --data-binary "<delete><query>_root_:$escaped_findaidid</query></delete>"
+#     --data-binary "<delete><query>id:$escaped_findaidid*</query></delete>"
+
+curl --fail -X POST "$SOLR_WRITER/update?commit=true" \
+    -H "Content-Type: text/xml" \
+    --data-binary "<delete><query>_root_:$escaped_findaidid</query></delete>"
 
 # deal with any errors
 


### PR DESCRIPTION
Also fail on curl getting a non 200

One failure mode of the previous query, essentially if an emptry string was passed as the ark, was to delete all records in the index. We had some safeguards in place, but it feels too dangerous.