### PR TITLE
Run cache-invalidations for the encoded ark [arclight]

### DIFF
--- a/arclight/bin/bulk-index-from-s3
+++ b/arclight/bin/bulk-index-from-s3
@@ -45,12 +45,13 @@ for folder in /tmp/$1/*; do
     echo "Clearing Cache for $folder"
 
     REPO_NAME=$(bundle exec rake repo:urlized_name\[$REPOSITORY_ID\])
+    ENCODED_ARK=$(echo "$FINDING_AID_ARK" | sed 's/\//%2F/g')
     echo "Running cache invalidation for $FINDING_AID_ARK and $REPOSITORY_ID landing page"
     if [ -z "$CLOUDFRONT_DISTRIBUTION_ID" ]; then
       echo "CLOUDFRONT_DISTRIBUTION_ID not set, skipping cache invalidation."
     else
-      echo "Invalidating urls: /findaid/$FINDING_AID_ARK and /search?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=$REPO_NAME&sort=title_sort+asc"
-      cf=$(aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/findaid/$FINDING_AID_ARK" "/search?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=$REPO_NAME&sort=title_sort+asc")
+      echo "Invalidating urls: /findaid/$FINDING_AID_ARK, /findaid/$ENCODED_ARK, and /search?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=$REPO_NAME&sort=title_sort+asc"
+      cf=$(aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/findaid/$FINDING_AID_ARK" "/findaid/$ENCODED_ARK" "/search?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=$REPO_NAME&sort=title_sort+asc")
       echo "Invalidation submitted: $cf"
     fi
 

--- a/arclight/bin/bulk-remove-from-solr
+++ b/arclight/bin/bulk-remove-from-solr
@@ -47,6 +47,8 @@ do
     repo_code="$(echo "$repo_code" | sed 's/^ *//;s/ *$//')"
     repo_name=$(bundle exec rake repo:urlized_name[$repo_code])
     paths+="\"/findaid/$findaid_id\" "
+    encoded_ark=$(echo "$findaid_id" | sed 's/\//%2F/g')
+    paths+="\"/findaid/$encoded_ark\" "
     # Only add the repository search path if we haven't seen this repo_name before
     if [[ -z "${repo_names_seen[$repo_name]}" ]]; then
         paths+="\"/search?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=$repo_name&sort=title_sort+asc\" "

--- a/arclight/bin/index-from-s3
+++ b/arclight/bin/index-from-s3
@@ -59,7 +59,9 @@ echo "Running cache invalidation for $4 and $3 landing page"
 if [ -z "$CLOUDFRONT_DISTRIBUTION_ID" ]; then
   echo "CLOUDFRONT_DISTRIBUTION_ID not set, skipping cache invalidation."
 else
-  echo "Invalidating urls: /findaid/$4 and /search?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=$REPO_NAME&sort=title_sort+asc"
-  cf=$(aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/findaid/$4" "/search?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=$REPO_NAME&sort=title_sort+asc")
+  # url encode the ark
+  ENCODED_ARK=$(echo "$4" | sed 's/\//%2F/g')
+  echo "Invalidating urls: /findaid/$4, /findaid/$ENCODED_ARK, and /search?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=$REPO_NAME&sort=title_sort+asc"
+  cf=$(aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/findaid/$4" "/findaid/$ENCODED_ARK" "/search?f%5Blevel%5D%5B%5D=Collection&f%5Brepository%5D%5B%5D=$REPO_NAME&sort=title_sort+asc")
   echo "Invalidation submitted: $cf"
 fi


### PR DESCRIPTION
I think this should resolve the cache invalidation issues we've been seeing - it runs an invalidation for both: `/findaid/ark:/12345/abcd1234` and `/findaid/ark:%2F12345%2Fabcd1234`