### PR TITLE
406 error investigation

### DIFF
--- a/arclight/app/controllers/application_controller.rb
+++ b/arclight/app/controllers/application_controller.rb
@@ -6,4 +6,18 @@ class ApplicationController < ActionController::Base
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  # temporarily log accept headers and rails-determined formats
+  # to debug 406 errors TODO: remove after debugging
+  before_action :log_accept_and_format
+
+  private
+  def log_accept_and_format
+    Rails.logger.info({
+      accept: request.headers["Accept"],
+      requested_format: request.format&.to_s,
+      params_format: params[:format],
+      path: request.fullpath
+    }.to_json)
+  end
 end

--- a/arclight/app/controllers/errors_controller.rb
+++ b/arclight/app/controllers/errors_controller.rb
@@ -1,5 +1,5 @@
 class ErrorsController < ApplicationController
     def not_found
-        render status: :not_found
+        render "errors/not_found", status: :not_found
     end
 end


### PR DESCRIPTION
I'm seeing a lot of 406 errors in the log, and format is typically HTML, which Rails should have no problem dealing with. I don't actually see the request in the logs, though, so I wonder if Rails is doing something funky in its conversion of the Accepts header to format. 

I'm seeing some 406 errors for the ErrorsController, even, so I also made explicit where to find the not_found template. Rails shouldn't actually need this, but I wonder if it helps? 

This is related to card #830 