### PR TITLE
Add routes for /dsc/ and /admin/ after ark urls

### DIFF
--- a/arclight/config/routes.rb
+++ b/arclight/config/routes.rb
@@ -29,6 +29,17 @@ Rails.application.routes.draw do
   # esacped OAC4 static URLS like /findaid/ark:/13030/ju7h7eed3/entire_text
   get "/findaid/*ark/entire_text", to: "arks#findaid_static", constraints: { ark: /ark\:%2F[0-9]{5}%2F[0-9a-zA-Z]+/ }
 
+  # OAC4 style URLS like /findaid/ark:/13030/ju7h7eed3/admin
+  get "/findaid/*ark/admin", to: "arks#findaid", constraints: { ark: /ark\:\/[0-9]{5}\/[0-9a-zA-Z]+/ }
+  # esacped OAC4 style URLS like /findaid/ark:/13030/ju7h7eed3/admin
+  get "/findaid/*ark/admin", to: "arks#findaid", constraints: { ark: /ark\:%2F[0-9]{5}%2F[0-9a-zA-Z]+/ }
+
+  # OAC4 style URLS like /findaid/ark:/13030/ju7h7eed3/dsc
+  get "/findaid/*ark/dsc", to: "arks#findaid", constraints: { ark: /ark\:\/[0-9]{5}\/[0-9a-zA-Z]+/ }
+  # esacped OAC4 style URLS like /findaid/ark:/13030/ju7h7eed3/dsc
+  get "/findaid/*ark/dsc", to: "arks#findaid", constraints: { ark: /ark\:%2F[0-9]{5}%2F[0-9a-zA-Z]+/ }
+
+
   # OAC4 like /findaid/ark:/13030/ju7h7eed3
   get "/findaid/*ark", to: "arks#findaid", constraints: { ark: /ark\:\/[0-9]{5}\/[0-9a-zA-Z]+/ }
 

--- a/arclight/spec/routing/findaid_spec.rb
+++ b/arclight/spec/routing/findaid_spec.rb
@@ -31,6 +31,47 @@ it "routes unescaped /findaid/ark:/*/entire_text/ to the static_finding_aid cont
       )
   end
 
+  it "routes admin after ark to the the findaid controller" do
+    expect(get("/findaid/ark:/13010/sdfsdfsf/admin")).to route_to(
+      controller: "arks",
+      action: "findaid",
+      ark: "ark:/13010/sdfsdfsf"
+      )
+  end
+
+    it "routes admin/ after ark to the the findaid controller" do
+    expect(get("/findaid/ark:/13010/sdfsdfsf/admin/")).to route_to(
+      controller: "arks",
+      action: "findaid",
+      ark: "ark:/13010/sdfsdfsf"
+      )
+  end
+
+    it "routes dsc after ark to the the findaid controller" do
+    expect(get("/findaid/ark:/13010/sdfsdfsf/dsc")).to route_to(
+      controller: "arks",
+      action: "findaid",
+      ark: "ark:/13010/sdfsdfsf"
+      )
+  end
+
+    it "routes dsc/ after ark to the the findaid controller" do
+    expect(get("/findaid/ark:/13010/sdfsdfsf/dsc/")).to route_to(
+      controller: "arks",
+      action: "findaid",
+      ark: "ark:/13010/sdfsdfsf"
+      )
+  end
+
+      it "routes dsc/ after ark to the the findaid controller" do
+    expect(get("/findaid/ark:/13010/sdfsdfsf/dsc/?query=")).to route_to(
+      controller: "arks",
+      action: "findaid",
+      ark: "ark:/13010/sdfsdfsf",
+      query: ""
+      )
+  end
+
 it "routes garbage after ark to the 404 controller" do
     expect(get("/findaid/ark:/13010/sdfsdfsf/garbage")).to route_to(
       controller: "errors",


### PR DESCRIPTION
Handles old OAC4 routes and redirects them to finding aid landing pages