### PR TITLE
Arclight: remove revision_ssm field from traject mapping

### DIFF
--- a/arclight/lib/arclight/traject/ead2_config.rb
+++ b/arclight/lib/arclight/traject/ead2_config.rb
@@ -336,17 +336,17 @@ to_field "sponsor_tesim", extract_xpath("/ead/eadheader/filedesc/titlestmt/spons
 to_field "date_prepared_ssm", extract_xpath("/ead/eadheader/filedesc/publicationstmt/date")
 to_field "date_encoded_ssm", extract_xpath("/ead/eadheader/profiledesc/creation")
 
-to_field "revision_ssm" do |record, accumulator|
-  changes = record.xpath("/ead/eadheader/revisiondesc/change")
-  dates_and_items_per_change = changes.map do |change|
-    dates = change.xpath("./date").map { |d| d.text.strip }
-    items = change.xpath("./item").map  { |i| i.text.strip }
-    dates_and_items = dates + items
-    dates_and_items.join("<br/>") unless dates_and_items.empty?
-  end
+# to_field "revision_ssm" do |record, accumulator|
+#   changes = record.xpath("/ead/eadheader/revisiondesc/change")
+#   dates_and_items_per_change = changes.map do |change|
+#     dates = change.xpath("./date").map { |d| d.text.strip }
+#     items = change.xpath("./item").map  { |i| i.text.strip }
+#     dates_and_items = dates + items
+#     dates_and_items.join("<br/>") unless dates_and_items.empty?
+#   end
 
-  accumulator.concat(dates_and_items_per_change)
-end
+#   accumulator.concat(dates_and_items_per_change)
+# end
 
 to_field "editionstmt_ssm", extract_xpath("/ead/eadheader/filedesc/editionstmt/p")
 to_field "seriesstmt_ssm", extract_xpath("/ead/eadheader/filedesc/seriesstmt/p")


### PR DESCRIPTION
This PR removes the revision_ssm field from the traject configuration. I commented this out rather than deleting in case we ever do want to map this field in future, since the logic took a little while to figure out.

The field was removed from the frontend display in a separate PR: https://github.com/ucldc/cinco/pull/1048