### PR TITLE
Whitelist hierarchy request field list [arclight]

### DIFF
--- a/arclight/app/models/concerns/arclight/search_behavior.rb
+++ b/arclight/app/models/concerns/arclight/search_behavior.rb
@@ -29,6 +29,22 @@ module Arclight
       solr_parameters[:start] = blacklight_params[:offset] if blacklight_params[:offset]
       solr_parameters[:sort] = "sort_isi asc"
       solr_parameters[:facet] = false
+      # Optimize performance by only fetching fields needed for hierarchy display
+      solr_parameters[:fl] = [
+        "id",
+        "title_ssm",
+        "normalized_title_ssm",
+        "level_ssm",
+        "sort_isi",
+        "ref_ssi",
+        "unitid_ssm",
+        "containers_ssim",
+        "extent_ssm",
+        "unitdate_ssm",
+        "normalized_date_ssm",
+        "child_component_count_isi",
+        "_nest_path_"
+      ].join(",")
     end
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 


### PR DESCRIPTION
I'm not totally sure how to test this, especially since it seems these hierarchy queries are particularly slow on production but not on stage? 

Maybe I time curl `https://oac.cdlib.org/findaid/<ark>/hierarchy?hierarchy=true` for the finding aids with the most children, and then deploy this change and see if it has any effect? 