### PR TITLE
Rebuild Static Finding Aids in an ECS Task

### DIFF
--- a/arclight/bin/generate-static-findaid
+++ b/arclight/bin/generate-static-findaid
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+# This script takes as an argument the ARK of a finding aid and generates
+# a static finding aid by fetching from Solr and uploading the result to S3.
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <finding_aid_ark>"
+  exit 1
+fi
+
+echo "Generating static finding aid for ARK: $1"
+SOLR_TREE_TIMEOUT_SECONDS=300 bundle exec rake static_finding_aid:generate["$1"]

--- a/arclight/bin/generate-static-findaid
+++ b/arclight/bin/generate-static-findaid
@@ -9,4 +9,4 @@ if [ -z "$1" ]; then
 fi
 
 echo "Generating static finding aid for ARK: $1"
-SOLR_TREE_TIMEOUT_SECONDS=300 bundle exec rake static_finding_aid:generate["$1"]
+bundle exec rake static_finding_aid:generate["$1"]

--- a/arclight/bin/index-from-s3
+++ b/arclight/bin/index-from-s3
@@ -24,10 +24,21 @@ if [ -z "$SOLR_WRITER" ]; then
 fi
 
 echo "Downloading Finding Aid ID: $1 to /tmp/$1"
-# aws s3 sync s3://$S3_BUCKET/media/$2 /tmp/$1
 mkdir -p /tmp/$1
-curl https://$S3_BUCKET.s3.us-west-2.amazonaws.com/media/$2/finding-aid.xml > /tmp/$1/finding-aid.xml
-curl https://$S3_BUCKET.s3.us-west-2.amazonaws.com/media/$2/extracted-supplementary-files-text.txt > /tmp/$1/extracted-supplementary-files-text.txt
+
+# if CINCO_MINIO_ENDPOINT is set, configure aws cli to use local minio endpoint
+if [ -n "$CINCO_MINIO_ENDPOINT" ]; then
+  echo "Using Minio endpoint: $CINCO_MINIO_ENDPOINT"
+  export AWS_ACCESS_KEY_ID="minioadmin"
+  export AWS_SECRET_ACCESS_KEY="minioadmin"
+  export AWS_DEFAULT_REGION="us-east-1"
+  S3_CLI_ENDPOINT="--endpoint-url $CINCO_MINIO_ENDPOINT"
+else
+  S3_CLI_ENDPOINT=""
+fi
+
+aws s3 cp s3://$S3_BUCKET/media/$2/finding-aid.xml /tmp/$1/finding-aid.xml $S3_CLI_ENDPOINT
+aws s3 cp s3://$S3_BUCKET/media/$2/extracted-supplementary-files-text.txt /tmp/$1/extracted-supplementary-files-text.txt $S3_CLI_ENDPOINT || true
 
 echo "Setting Repository Code Environment Variable"
 export REPOSITORY_ID=$3

--- a/arclight/lib/tasks/static_finding_aid.rake
+++ b/arclight/lib/tasks/static_finding_aid.rake
@@ -54,6 +54,7 @@ namespace :static_finding_aid do
     end
   end
 
+  # TODO: untested and will likely need adjustments to work, but a good starting place
   desc "Generate static finding aids for multiple Solr IDs from a file"
   task :generate_batch, [ :file_path ] => :environment do |_t, args|
     unless args[:file_path].present? && File.exist?(args[:file_path])

--- a/arclight/lib/tasks/static_finding_aid.rake
+++ b/arclight/lib/tasks/static_finding_aid.rake
@@ -12,7 +12,7 @@ namespace :static_finding_aid do
 
     begin
       # Create a proper request environment
-      env = Rack::MockRequest.env_for("http://localhost:3000/static_finding_aid/#{id}")
+      env = Rack::MockRequest.env_for("http://localhost:3000/findaid/static/#{id}")
       env["rack.session"] = {}
       env["rack.session.options"] = {}
       request = ActionDispatch::Request.new(env)
@@ -33,12 +33,15 @@ namespace :static_finding_aid do
         # Check if it was uploaded to S3
         if ENV["S3_BUCKET"].present?
           puts "✓ Content uploaded to S3 bucket: #{ENV['S3_BUCKET']}"
-          puts "  Path: static_findaids/static_findaids/#{id}.html"
+          puts "  Path: static_findaids/oac5/#{id}.html"
         else
           puts "⚠ S3_BUCKET not configured - content not uploaded to S3"
         end
       elsif response.status == 302
         puts "✗ Document not found in Solr - redirected to /findaid/#{id}"
+        exit 1
+      elsif response.status == 503
+        puts "✗ Solr tree fetch timed out for #{id} - background render job queued"
         exit 1
       else
         puts "✗ Failed with status: #{response.status}"
@@ -72,7 +75,7 @@ namespace :static_finding_aid do
       print "[#{index + 1}/#{total}] Processing #{id}... "
 
       begin
-        env = Rack::MockRequest.env_for("http://localhost:3000/static_finding_aid/#{id}")
+        env = Rack::MockRequest.env_for("http://localhost:3000/findaid/static/#{id}")
         env["rack.session"] = {}
         env["rack.session.options"] = {}
         request = ActionDispatch::Request.new(env)
@@ -88,6 +91,9 @@ namespace :static_finding_aid do
         if response.status == 200
           puts "✓"
           success_count += 1
+        elsif response.status == 503
+          puts "✗ (timeout - background render job queued)"
+          failure_count += 1
         else
           puts "✗ (status: #{response.status})"
           failure_count += 1

--- a/dags/arclight_operator.py
+++ b/dags/arclight_operator.py
@@ -140,6 +140,10 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
         env = [
             {"name": "SOLR_WRITER", "value": solr_leader_url},
             {"name": "CLOUDFRONT_DISTRIBUTION_ID", "value": cf_distro},
+            {
+                "name": "SOLR_TREE_TIMEOUT_SECONDS",
+                "value": "150",
+            },  # 2.5 minute timeout for static findaid generation
         ]
         if self.arclight_command == "generate-static-findaid":
             env.append({"name": "SOLR_URL", "value": solr_leader_url})
@@ -208,6 +212,7 @@ class ArcLightDockerOperator(DockerOperator):
                 "CINCO_MINIO_ENDPOINT": os.environ.get("CINCO_MINIO_ENDPOINT", ""),
                 "SOLR_URL": "http://solr:8983/solr/arclight",
                 "SOLR_WRITER": "http://solr:8983/solr/arclight",
+                "SOLR_TREE_TIMEOUT_SECONDS": 150,  # 2.5 minute timeout for static findaid generation
             },
             "max_active_tis_per_dag": 4,
         }

--- a/dags/arclight_operator.py
+++ b/dags/arclight_operator.py
@@ -65,6 +65,7 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
         preview=None,
         **kwargs,
     ):
+        self.arclight_command = arclight_command
         container_name = f"cinco-arclight-{ cinco_environment }-container"
         # TODO: specify task definition revision? how?
         ecs_names = {
@@ -92,6 +93,8 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
             command = [f"bin/{arclight_command}", finding_aid_ark, repository_code]
         elif arclight_command == "bulk-remove-from-solr":
             command = [f"bin/{arclight_command}", s3_key]
+        elif arclight_command == "generate-static-findaid":
+            command = [f"bin/{arclight_command}", finding_aid_ark]
 
         args = {
             "launch_type": "FARGATE",
@@ -133,10 +136,14 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
         else:
             cf_distro = Variable.get("CINCO_CLOUDFRONT_STG")
 
-        self.overrides["containerOverrides"][0]["environment"] = [
-            {"name": "SOLR_WRITER", "value": get_solr_writer_url(cinco_environment)},
+        solr_leader_url = get_solr_writer_url(cinco_environment)
+        env = [
+            {"name": "SOLR_WRITER", "value": solr_leader_url},
             {"name": "CLOUDFRONT_DISTRIBUTION_ID", "value": cf_distro},
         ]
+        if self.arclight_command == "generate-static-findaid":
+            env.append({"name": "SOLR_URL", "value": solr_leader_url})
+        self.overrides["containerOverrides"][0]["environment"] = env
         return super().execute(context)
 
 
@@ -185,6 +192,8 @@ class ArcLightDockerOperator(DockerOperator):
             command = [f"bin/{arclight_command}", finding_aid_ark, repository_code]
         elif arclight_command == "bulk-remove-from-solr":
             command = [f"bin/{arclight_command}", s3_key]
+        elif arclight_command == "generate-static-findaid":
+            command = [f"bin/{arclight_command}", finding_aid_ark]
 
         args = {
             "image": f"{container_image}:{container_version}",

--- a/dags/arclight_operator.py
+++ b/dags/arclight_operator.py
@@ -148,6 +148,15 @@ class ArcLightEcsOperator(EcsRunTaskOperator):
         if self.arclight_command == "generate-static-findaid":
             env.append({"name": "SOLR_URL", "value": solr_leader_url})
         self.overrides["containerOverrides"][0]["environment"] = env
+
+        if (
+            cinco_environment == "prd"
+            and self.arclight_command == "generate-static-findaid"
+        ):
+            print(self.overrides)
+            print("CURRENTLY TESTING THIS TASK IN STAGE ONLY - SKIP IN PRD FOR NOW")
+            return
+
         return super().execute(context)
 
 

--- a/dags/bulk_delete_finding_aids.py
+++ b/dags/bulk_delete_finding_aids.py
@@ -56,13 +56,18 @@ def bulk_delete_finding_aid():
         removals = s3.get_object(Bucket=bucket_name, Key=s3_key)
         removals = removals["Body"].read().decode("utf-8").splitlines()
 
+        bucket = s3.Bucket(bucket_name)
         for line in removals:
             ark, _ = line.split(",", 1)
-            prefix = f"static_findaids/static_findaids/{ark}"
-            print(f"Deleting objects in {bucket_name} at {prefix}")
-            bucket = s3.Bucket(bucket_name)
-            delete_results = bucket.objects.filter(Prefix=prefix).delete()
-            print(delete_results)
+            prefixes = [
+                f"static_findaids/static_findaids/{ark}",
+                f"static_findaids/oac4/{ark}",
+                f"static_findaids/oac5/{ark}",
+            ]
+            for prefix in prefixes:
+                print(f"Deleting objects in {bucket_name} at {prefix}")
+                delete_results = bucket.objects.filter(Prefix=prefix).delete()
+                print(delete_results)
 
     (
         bulk_remove_from_index

--- a/dags/bulk_index_finding_aids.py
+++ b/dags/bulk_index_finding_aids.py
@@ -133,6 +133,7 @@ def bulk_index_finding_aids():
         s3_key=s3_key, cinco_environment="{{ params.cinco_environment }}"
     )
 
+    # TODO: request a static finding aid rebuild for each finding aid
     (
         bulk_prepare_finding_aids_task
         >> finding_aid_batches

--- a/dags/delete_finding_aid.py
+++ b/dags/delete_finding_aid.py
@@ -55,11 +55,16 @@ def delete_finding_aid():
         else:
             bucket_name = Variable.get("CINCO_S3_BUCKET_STAGE")
 
-        prefix = f"static_findaids/static_findaids/{ark}"
-        print(f"Deleting objects in {bucket_name} at {prefix}")
-        bucket = s3.Bucket(bucket_name)
-        delete_results = bucket.objects.filter(Prefix=prefix).delete()
-        print(delete_results)
+        prefixes = [
+            f"static_findaids/static_findaids/{ark}",
+            f"static_findaids/oac4/{ark}",
+            f"static_findaids/oac5/{ark}",
+        ]
+        for prefix in prefixes:
+            print(f"Deleting objects in {bucket_name} at {prefix}")
+            bucket = s3.Bucket(bucket_name)
+            delete_results = bucket.objects.filter(Prefix=prefix).delete()
+            print(delete_results)
 
     (
         remove_from_index

--- a/dags/index_finding_aid.py
+++ b/dags/index_finding_aid.py
@@ -1,5 +1,6 @@
+import os
+
 import boto3
-import requests
 from datetime import datetime
 from airflow.decorators import dag, task
 from airflow.models.param import Param
@@ -79,45 +80,45 @@ def index_finding_aid():
 
     @task()
     def cleanup_s3(s3_key, cinco_environment="stage"):
-        s3 = boto3.resource("s3")
-        if cinco_environment == "prd":
-            bucket_name = Variable.get("CINCO_S3_BUCKET_PRD")
+        cinco_minio_endpoint = os.environ.get("CINCO_MINIO_ENDPOINT", None)
+        if cinco_minio_endpoint:
+            s3 = boto3.resource(
+                "s3",
+                endpoint_url=cinco_minio_endpoint,
+                aws_access_key_id="minioadmin",
+                aws_secret_access_key="minioadmin",
+                region_name="us-east-1",
+            )
+            bucket_name = "cinco-dev"
         else:
-            bucket_name = Variable.get("CINCO_S3_BUCKET_STAGE")
+            s3 = boto3.resource("s3")
+            if cinco_environment == "prd":
+                bucket_name = Variable.get("CINCO_S3_BUCKET_PRD")
+            else:
+                bucket_name = Variable.get("CINCO_S3_BUCKET_STAGE")
+
         prefix = f"media/{s3_key}"
         print(f"Deleting objects in {bucket_name} at {prefix}")
         bucket = s3.Bucket(bucket_name)
         delete_results = bucket.objects.filter(Prefix=prefix).delete()
         print(delete_results)
 
-    @task(pool="cinco_solr_expensive_query_pool")
-    def request_staticfindaid_rebuild(finding_aid_id, cinco_environment="stage"):
-        if cinco_environment == "prd":
-            url = f"https://oac.cdlib.org/findaid/static/{finding_aid_id}"
-        else:
-            url = f"https://oac-stg.cdlib.org/findaid/static/{finding_aid_id}"
-
-        resp = requests.get(url)
-        if resp.status_code == 503:
-            print(f"Static Finding Aid service is rebuilding {finding_aid_id}")
-        elif resp.status_code == 200:
-            print(f"Static Finding Aid for {finding_aid_id} built successfully")
-        else:
-            raise Exception(
-                "Unexpected response from Static Finding Aid service: \n"
-                f"    url: {url}\n"
-                f"    {resp.status_code} - {resp.text}"
-            )
+    request_staticfindaid_rebuild = ArcLightOperator(
+        task_id="request_staticfindaid_rebuild",
+        arclight_command="generate-static-findaid",
+        finding_aid_ark="{{ params.finding_aid_ark }}",
+        cinco_environment="{{ params.cinco_environment }}",
+        pool="cinco_solr_expensive_query_pool",
+        # on_failure_callback=notify_failure,
+        # on_success_callback=notify_success
+    )
 
     (
         s3_key
         >> prepare_finding_aid
         >> index_finding_aid_task
         >> cleanup_s3(s3_key, cinco_environment="{{ params.cinco_environment }}")
-        >> request_staticfindaid_rebuild(
-            "{{ params.finding_aid_id }}",
-            cinco_environment="{{ params.cinco_environment }}",
-        )
+        >> request_staticfindaid_rebuild
     )
 
 


### PR DESCRIPTION
Since replication doesn't happen as part of the reindexing process and we can't be certain that the live site (oac.cdlib.org or oac-stg.cdlib.org) has the latest and greatest finding aid information, we need to rebuild the static finding aids against the solr leader, not the solr followers. 

So instead of creating a new static finding aid via a small python task running a request against the live site, we need to:

Spin up an ECS task with the SOLR_URL=the solr leader url, set the solr timeout to 2.5 seconds, and try to rebuild the static finding aid in this timeframe via a shell script/rake task pair. 

The solr timeout is configurable within the DAG, but not within Airflow. The pool is configurable within Airflow. 