### PR TITLE
MARC filter

### DIFF
--- a/arclight/app/controllers/catalog_controller.rb
+++ b/arclight/app/controllers/catalog_controller.rb
@@ -166,6 +166,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "places", field: "geogname_ssim", limit: 10
     config.add_facet_field "access_subjects", field: "access_subjects_ssim", limit: 10
     config.add_facet_field "level", field: "level_ssim", limit: 10, show: false
+    config.add_facet_field "source_format", field: "source_format_ssi", limit: 10, show: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/arclight/app/controllers/catalog_controller.rb
+++ b/arclight/app/controllers/catalog_controller.rb
@@ -166,7 +166,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "places", field: "geogname_ssim", limit: 10
     config.add_facet_field "access_subjects", field: "access_subjects_ssim", limit: 10
     config.add_facet_field "level", field: "level_ssim", limit: 10, show: false
-    config.add_facet_field "source_format", field: "source_format_ssi", limit: 10, show: false
+    config.add_facet_field "source_format", field: "cincoctrl_source_format_ssi", limit: 10, show: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/arclight/bin/index-all-marc
+++ b/arclight/bin/index-all-marc
@@ -18,8 +18,8 @@ bin/index-marc-from-s3 SFMSS22-6.mrc csf_sfpl
 bin/index-marc-from-s3 SFMSS29-6.mrc csf_sfpl
 bin/index-marc-from-s3 sfp35.mrc csf_sfpl
 bin/index-marc-from-s3 sfp70sfp15.mrc csf_sfpl
-bin/index-marc-from-s3 UC_Davis.Shields.mrc ucdavis_spcoll
-bin/index-marc-from-s3 UC_Davis_AR.mrc ucdavis_uarc
+# bin/index-marc-from-s3 UC_Davis.Shields.mrc ucdavis_spcoll
+# bin/index-marc-from-s3 UC_Davis_AR.mrc ucdavis_uarc
 bin/index-marc-from-s3 ucsb.spcoll.oac.mrc ucsb_spcoll
 bin/index-marc-from-s3 UC_Santa_Cruz.Spec_Coll.mrc ucsb_spcoll
 bin/index-marc-from-s3 UC_Santa_Cruz.UA.mrc ucsc_uarc

--- a/arclight/lib/arclight/traject/ead2_config.rb
+++ b/arclight/lib/arclight/traject/ead2_config.rb
@@ -352,6 +352,10 @@ to_field "editionstmt_ssm", extract_xpath("/ead/eadheader/filedesc/editionstmt/p
 to_field "seriesstmt_ssm", extract_xpath("/ead/eadheader/filedesc/seriesstmt/p")
 to_field "note_ssm", extract_xpath("/ead/eadheader/filedesc/notestmt/note/p")
 
+to_field "source_format_ssi" do |_record, accumulator|
+  accumulator << "ead"
+end
+
 # =============================
 # Each component child document
 # <c> <c01> <c12>

--- a/arclight/lib/arclight/traject/ead2_config.rb
+++ b/arclight/lib/arclight/traject/ead2_config.rb
@@ -352,10 +352,6 @@ to_field "editionstmt_ssm", extract_xpath("/ead/eadheader/filedesc/editionstmt/p
 to_field "seriesstmt_ssm", extract_xpath("/ead/eadheader/filedesc/seriesstmt/p")
 to_field "note_ssm", extract_xpath("/ead/eadheader/filedesc/notestmt/note/p")
 
-to_field "source_format_ssi" do |_record, accumulator|
-  accumulator << "ead"
-end
-
 # =============================
 # Each component child document
 # <c> <c01> <c12>

--- a/arclight/lib/arclight/traject/marc_config.rb
+++ b/arclight/lib/arclight/traject/marc_config.rb
@@ -256,6 +256,6 @@ to_field "sort_isi" do |_record, accumulator, _context|
   accumulator << 0
 end
 
-to_field "source_format_ssi" do |_record, accumulator|
+to_field "cincoctrl_source_format_ssi" do |_record, accumulator|
   accumulator << "marc"
 end

--- a/arclight/lib/arclight/traject/marc_config.rb
+++ b/arclight/lib/arclight/traject/marc_config.rb
@@ -255,3 +255,7 @@ end
 to_field "sort_isi" do |_record, accumulator, _context|
   accumulator << 0
 end
+
+to_field "source_format_ssi" do |_record, accumulator|
+  accumulator << "marc"
+end

--- a/arclight/lib/arclight/traject/naming-conventions.md
+++ b/arclight/lib/arclight/traject/naming-conventions.md
@@ -1,0 +1,7 @@
+# Field Names
+
+1. Archival fields get unqualified names, ex: `subtitle_tesim`
+
+2. If an archival field name required for OAC conflicts with the ArcLight name, and we cannot simply change the mapping for the ArcLight field of the same name, then add an `oac_` prefix, ex: `oac_normalized_title_ssm`
+
+3. Systems-level, Administrative Fields should have a `cincoctrl_` prefix, ex: `cincoctrl_source_format_ssi`


### PR DESCRIPTION
I'd like to add a field to differentiate MARC from EAD in Solr - my current best working field name is `source_format_ssi`. I propose we add it to the traject mapping and reindex all MARC, so all those records would immediately get this field. 

~EADs moving forward would also get it. Historically indexed EADs would have an empty `source_format_ssi` field (but since this field is an either/or, that's okay). All record express records would have a `source_format_ssi = ead`~ 

I heard feedback that record express/EAD disambiguation would be valuable, as well, but this is a bigger lift. For now, only add this field to MARC records, to provide filtering for MARC. 

Contributors would be able to review their MARC records by appending `&f[source_format][]=marc` to the end of a search URL. ex: `/search?group=true&q=&search_field=all_fields&f[source_format][]=marc`

We could do this without restarting Solr. 