### PR TITLE
Reduce latency between indexing & seeing the file on OAC site

### DIFF
--- a/arclight/bin/index-from-s3
+++ b/arclight/bin/index-from-s3
@@ -65,12 +65,3 @@ unset REPOSITORY_ID
 
 echo "Finished indexing, cleaning up /tmp/$1"
 rm -rf /tmp/$1
-
-if [ -z "$CLOUDFRONT_DISTRIBUTION_ID" ]; then
-  echo "CLOUDFRONT_DISTRIBUTION_ID not set, skipping cache invalidation."
-else
-  echo "Running cache invalidation for 1 path"
-  echo "Invalidating urls: /findaid/$4*"
-  cf=$(aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/findaid/$4*")
-  echo "Invalidation submitted: $cf"
-fi

--- a/dags/index_finding_aid.py
+++ b/dags/index_finding_aid.py
@@ -1,11 +1,11 @@
 import os
 
 import boto3
-import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from airflow.decorators import dag, task
 from airflow.models.param import Param
 from airflow.models import Variable
+from airflow.sensors.time_delta import TimeDeltaSensor
 
 from cinco.cincoctrl_operator import CincoCtrlOperator
 from cinco.arclight_operator import ArcLightOperator
@@ -114,11 +114,15 @@ def index_finding_aid():
         # on_success_callback=notify_success
     )
 
+    # wait for 1 minute to allow time for solr autocommit &
+    # replication to complete
+    wait_one_minute = TimeDeltaSensor(
+        task_id="wait_one_minute",
+        delta=timedelta(minutes=1),
+    )
+
     @task()
     def clear_cloudfront_cache(finding_aid_id, cinco_environment="stage"):
-        # wait for 1 minute to allow time for solr autocommit &
-        # replication to complete
-        time.sleep(60)
         if cinco_environment == "prd":
             cf_distro = Variable.get("CINCO_CLOUDFRONT_PRD")
         else:
@@ -146,6 +150,7 @@ def index_finding_aid():
         >> index_finding_aid_task
         >> cleanup_s3(s3_key, cinco_environment="{{ params.cinco_environment }}")
         >> request_staticfindaid_rebuild
+        >> wait_one_minute
         >> clear_cloudfront_cache(
             "{{ params.finding_aid_id }}",
             cinco_environment="{{ params.cinco_environment }}",

--- a/dags/index_finding_aid.py
+++ b/dags/index_finding_aid.py
@@ -1,6 +1,7 @@
 import os
 
 import boto3
+import time
 from datetime import datetime
 from airflow.decorators import dag, task
 from airflow.models.param import Param
@@ -113,12 +114,42 @@ def index_finding_aid():
         # on_success_callback=notify_success
     )
 
+    @task()
+    def clear_cloudfront_cache(finding_aid_id, cinco_environment="stage"):
+        # wait for 1 minute to allow time for solr autocommit &
+        # replication to complete
+        time.sleep(60)
+        if cinco_environment == "prd":
+            cf_distro = Variable.get("CINCO_CLOUDFRONT_PRD")
+        else:
+            cf_distro = Variable.get("CINCO_CLOUDFRONT_STG")
+
+        if not cf_distro:
+            print("CLOUDFRONT_DISTRIBUTION_ID not set, skipping cache invalidation.")
+        else:
+            print("Running cache invalidation for 1 path")
+            print(f"Invalidating urls: /findaid/{finding_aid_id}*")
+            cf = boto3.client("cloudfront").create_invalidation(
+                DistributionId=cf_distro,
+                InvalidationBatch={
+                    "Paths": {"Quantity": 1, "Items": [f"/findaid/{finding_aid_id}*"]},
+                    "CallerReference": str(datetime.now().timestamp()),
+                },
+            )
+            print(f"Invalidation submitted: {cf['Invalidation']['Id']}")
+
+        return
+
     (
         s3_key
         >> prepare_finding_aid
         >> index_finding_aid_task
         >> cleanup_s3(s3_key, cinco_environment="{{ params.cinco_environment }}")
         >> request_staticfindaid_rebuild
+        >> clear_cloudfront_cache(
+            "{{ params.finding_aid_id }}",
+            cinco_environment="{{ params.cinco_environment }}",
+        )
     )
 
 

--- a/dags/index_finding_aid.py
+++ b/dags/index_finding_aid.py
@@ -136,7 +136,13 @@ def index_finding_aid():
             cf = boto3.client("cloudfront").create_invalidation(
                 DistributionId=cf_distro,
                 InvalidationBatch={
-                    "Paths": {"Quantity": 1, "Items": [f"/findaid/{finding_aid_id}*"]},
+                    "Paths": {
+                        "Quantity": 2,
+                        "Items": [
+                            f"/findaid/{finding_aid_id}*"
+                            f"/findaid/static/{finding_aid_id}*"
+                        ],
+                    },
                     "CallerReference": str(datetime.now().timestamp()),
                 },
             )


### PR DESCRIPTION
Delay Cloudfront cache invalidation until _after_ rebuilding the static finding aid and for another minute longer to allow time for the solr index to perform an autocommit (once every minute) and replicate that change to the followers. This does have the side effect of making the indexing process take longer - folks watching cincoctrl will now have to wait longer for verification that their finding aid has been published. 

Since there is only one dag for stage and prod, deploying this would result in the immediate deployment to both stage and prod. Prod wouldn't have the `/bin/index-from-s3` updates, though, so for any overlapping timeframe, there would be multiple cloudfront cache invalidations triggering for production (one in `/bin/index-from-s3` and one in the DAG). Since this seems like a relatively safe update, I'd like to just minimize the time in between, and cut a patch release with this update shortly after pushing it to stage.